### PR TITLE
Fix ModuleOp ownership conflict (causing segfault)

### DIFF
--- a/lib/burnside/bridge.cc
+++ b/lib/burnside/bridge.cc
@@ -72,7 +72,7 @@ class MLIRConverter {
 
   M::MLIRContext &mlirContext;
   const Pa::CookedSource *cooked;
-  M::OwningModuleRef module;
+  M::ModuleOp module;
   std::unique_ptr<M::OpBuilder> builder;
   LabelMapType blockMap;  // map from flattened labels to MLIR blocks
   std::list<Closure> edgeQ;
@@ -82,7 +82,7 @@ class MLIRConverter {
   bool noInsPt{false};
 
   inline M::OpBuilder &build() { return *builder.get(); }
-  inline M::ModuleOp getMod() { return module.get(); }
+  inline M::ModuleOp getMod() { return module; }
   inline LabelMapType &blkMap() { return blockMap; }
   void setCurrentPos(const Pa::CharBlock &pos) { lastKnownPos = pos; }
 

--- a/tools/fml/fml.cc
+++ b/tools/fml/fml.cc
@@ -271,11 +271,11 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
       semanticsContext.defaultKinds(), &parsing.cooked());
   Br::crossBurnsideBridge(Br::getBridge(), parseTree);
   mlir::ModuleOp mlirModule{Br::getBridge().getModule()};
-  mlir::PassManager pm{mlirModule.getContext()};
   if (driver.dumpHLFIR) {
     llvm::outs() << ";== 1 ==\n";
     mlirModule.dump();
   }
+  mlir::PassManager pm{mlirModule.getContext()};
   pm.addPass(fir::createMemToRegPass());
   // Run FIR lowering and CSE as a pair
   pm.addPass(mlir::createCSEPass());


### PR DESCRIPTION
`BurnsideBridge` has an `mlir::OwningModuleRef` that is used in `crossBurnsideBridge` to instantiate the `MLIRConverter` module that also was an `mlir::OwningModuleRef`. However, the `MLIRConverter` in `crossBurnsideBridge` is a local that gets destroyed after the call causing its `module` to be destroyed. Because its `module` is pointing on the same `mlir::Operation` than the `BurnsideBridge` one, it was also destroying what is inside the bridge `mlir::OwningModuleRef` causing undef behaviours later.

This commit fix this by changing the `MLIRConverter` `module` to be an `mlir::ModuleOP` so that it does not destroy the `Operation*` from the bridge `mlir::OwningModuleRef`. Valgrind  is now happy with `fml` on simple f90 programs.

Also moves one variable declaration in `fml.cc` closer from its first use.