### PR TITLE
Add a small framework to lower intrinsic calls to runtime calls.

### DIFF
--- a/lib/burnside/CMakeLists.txt
+++ b/lib/burnside/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(FortranBurnside
   convert-expr.cc
   fe-helper.cc
   flattened.cc
+  intrinsics.cc
   runtime.cc
 )
 

--- a/lib/burnside/bridge.cc
+++ b/lib/burnside/bridge.cc
@@ -20,6 +20,7 @@
 #include "fir/FIROps.h"
 #include "fir/Type.h"
 #include "flattened.h"
+#include "intrinsics.h"
 #include "runtime.h"
 #include "../parser/parse-tree-visitor.h"
 #include "../semantics/tools.h"
@@ -73,6 +74,7 @@ class FIRConverter {
   std::list<Closure> edgeQ;
   std::map<const Pa::NonLabelDoStmt *, DoBoundsInfo> doMap;
   SymMap symbolMap;
+  IntrinsicLibrary intrinsics;
   Pa::CharBlock lastKnownPos;
   bool noInsPt{false};
 
@@ -110,10 +112,10 @@ class FIRConverter {
   }
 
   M::Value *createFIRAddr(M::Location loc, const SomeExpr *expr) {
-    return createSomeAddress(loc, build(), *expr, symbolMap);
+    return createSomeAddress(loc, build(), *expr, symbolMap, intrinsics);
   }
   M::Value *createFIRExpr(M::Location loc, const SomeExpr *expr) {
-    return createSomeExpression(loc, build(), *expr, symbolMap);
+    return createSomeExpression(loc, build(), *expr, symbolMap, intrinsics);
   }
   M::Value *createTemp(M::Type type, Se::Symbol *symbol = nullptr) {
     return createTemporary(toLocation(), build(), symbolMap, type, symbol);
@@ -622,7 +624,9 @@ class FIRConverter {
 public:
   FIRConverter(BurnsideBridge &bridge)
     : mlirContext{bridge.getMLIRContext()}, cooked{bridge.getCookedSource()},
-      module{bridge.getModule()} {}
+      module{bridge.getModule()}, intrinsics{IntrinsicLibrary::create(
+                                      IntrinsicLibrary::Version::LLVM,
+                                      mlirContext)} {}
   FIRConverter() = delete;
 
   template<typename A> constexpr bool Pre(const A &) { return true; }

--- a/lib/burnside/convert-expr.h
+++ b/lib/burnside/convert-expr.h
@@ -15,6 +15,8 @@
 #ifndef FORTRAN_BURNSIDE_CONVERT_EXPR_H_
 #define FORTRAN_BURNSIDE_CONVERT_EXPR_H_
 
+#include "intrinsics.h"
+
 /// [Coding style](https://llvm.org/docs/CodingStandards.html)
 
 namespace mlir {
@@ -43,10 +45,10 @@ class SymMap;
 
 mlir::Value *createSomeExpression(mlir::Location loc, mlir::OpBuilder &builder,
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
-    SymMap &symMap);
+    SymMap &symMap, const IntrinsicLibrary &);
 mlir::Value *createSomeAddress(mlir::Location loc, mlir::OpBuilder &builder,
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
-    SymMap &symMap);
+    SymMap &symMap, const IntrinsicLibrary &);
 
 mlir::Value *createTemporary(mlir::Location loc, mlir::OpBuilder &builder,
     SymMap &symMap, mlir::Type type, const semantics::Symbol *symbol);

--- a/lib/burnside/intrinsics.cc
+++ b/lib/burnside/intrinsics.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "intrinsics.h"
+#include "builder.h"
+
+/// [Coding style](https://llvm.org/docs/CodingStandards.html)
+
+namespace Fortran::burnside {
+
+// Define a simple static runtime description that will be transformed into
+// IntrinsicImplementation when building the IntrinsicLibrary.
+namespace runtime {
+enum class Type { f32, f64 };
+struct StaticDescription {
+  const char *name;
+  const char *symbol;
+  Type resultType;
+  std::vector<Type> argumentTypes;
+};
+
+// TODO
+// This table should be generated in a clever ways and probably shared with
+// lib/evaluate intrinsic folding.
+static const StaticDescription llvm[] = {
+    {"abs", "llvm.fabs.f32", Type::f32, {Type::f32}},
+    {"abs", "llvm.fabs.f64", Type::f64, {Type::f64}},
+    {"acos", "acosf", Type::f32, {Type::f32}},
+    {"acos", "acos", Type::f64, {Type::f64}},
+    {"atan", "atan2f", Type::f32, {Type::f32, Type::f32}},
+    {"atan", "atan2", Type::f64, {Type::f64, Type::f64}},
+    {"sqrt", "llvm.sqrt.f32", Type::f32, {Type::f32}},
+    {"sqrt", "llvm.sqrt.f64", Type::f64, {Type::f64}},
+    {"cos", "llvm.cos.f32", Type::f32, {Type::f32}},
+    {"cos", "llvm.cos.f64", Type::f64, {Type::f64}},
+    {"sin", "llvm.sin.f32", Type::f32, {Type::f32}},
+    {"sin", "llvm.sin.f64", Type::f64, {Type::f64}},
+};
+
+// Conversion between types of the static representation and MLIR types.
+mlir::Type toMLIRType(Type t, mlir::MLIRContext &context) {
+  switch (t) {
+  case Type::f32: return mlir::FloatType::getF32(&context);
+  case Type::f64: return mlir::FloatType::getF64(&context);
+  }
+}
+mlir::FunctionType toMLIRFunctionType(
+    const StaticDescription &func, mlir::MLIRContext &context) {
+  std::vector<mlir::Type> argMLIRTypes;
+  for (runtime::Type t : func.argumentTypes) {
+    argMLIRTypes.push_back(toMLIRType(t, context));
+  }
+  return mlir::FunctionType::get(
+      argMLIRTypes, toMLIRType(func.resultType, context), &context);
+}
+}  // runtime
+
+std::optional<mlir::FuncOp> IntrinsicLibrary::getFunction(
+    const std::string &name, const mlir::Type &type,
+    mlir::OpBuilder &builder) const {
+  auto module{getModule(&builder)};
+  if (const auto &it{lib.find({name, type})}; it != lib.end()) {
+    const IntrinsicImplementation &impl{it->second};
+    if (mlir::FuncOp func{getNamedFunction(impl.symbol)}) {
+      return func;
+    }
+    mlir::FuncOp function{createFunction(module, impl.symbol, impl.type)};
+    function.setAttr("fir.intrinsic", builder.getUnitAttr());
+    return function;
+  } else {
+    return std::nullopt;
+  }
+}
+
+// So far ignore the version an only load the dummy llvm lib.
+IntrinsicLibrary IntrinsicLibrary::create(
+    IntrinsicLibrary::Version, mlir::MLIRContext &context) {
+  Map map;
+  for (const auto &func : runtime::llvm) {
+    IntrinsicLibrary::Key key{
+        func.name, runtime::toMLIRType(func.resultType, context)};
+    IntrinsicImplementation impl{
+        func.symbol, runtime::toMLIRFunctionType(func, context)};
+    map.insert({key, impl});
+  }
+  return IntrinsicLibrary{std::move(map)};
+}
+}

--- a/lib/burnside/intrinsics.h
+++ b/lib/burnside/intrinsics.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_BURNSIDE_INTRINSICS_H_
+#define FORTRAN_BURNSIDE_INTRINSICS_H_
+
+#include "mlir/Dialect/StandardOps/Ops.h"
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+/// [Coding style](https://llvm.org/docs/CodingStandards.html)
+
+namespace Fortran::burnside {
+
+/// IntrinsicLibrary holds the runtime description of intrinsics. It aims
+/// at abstracting which library version is used to implement Fortran
+/// numerical intrinsics while lowering expressions.
+/// It can be probed for a certain intrinsic and will return an mlir::FuncOp
+/// that matches the targeted library implementation.
+class IntrinsicLibrary {
+public:
+  /// Available intrinsic library versions.
+  enum class Version { PgmathFast, PgmathRelaxed, PgmathPrecise, LLVM };
+  using Key = std::pair<std::string, mlir::Type>;
+  // Need a custom hash for this kind of keys. LLVM provides it.
+  struct Hash {
+    size_t operator()(const Key &k) const { return llvm::hash_value(k); }
+  };
+  /// Internal structure to describe the runtime function. An intrinsic function
+  /// is not declared in mlir until the IntrinsicLibrary needs to return it.
+  /// This is to avoid polluting the LLVM IR with useless declarations.
+  /// This structure allows generating mlir::FuncOp on the fly.
+  struct IntrinsicImplementation {
+    IntrinsicImplementation(const std::string &n, mlir::FunctionType t)
+      : symbol{n}, type{t} {};
+    std::string symbol;
+    mlir::FunctionType type;
+  };
+  using Map = std::unordered_map<Key, IntrinsicImplementation, Hash>;
+
+  /// Probe the intrinsic library for a certain intrinsic and get/build the
+  /// related mlir::FuncOp if a runtime description is found.
+  /// Also add an unit attribute "fir.intrinsic" to the function so that later
+  /// it is possible to quickly know what function are intrinsics vs users.
+  std::optional<mlir::FuncOp> getFunction(
+      const std::string &, const mlir::Type &, mlir::OpBuilder &) const;
+
+  /// Create the runtime description for the targeted library version.
+  static IntrinsicLibrary create(Version, mlir::MLIRContext &);
+
+private:
+  IntrinsicLibrary(Map &&l) : lib{std::move(l)} {};
+  /// Holds the intrinsic runtime description to be probed.
+  Map lib;
+};
+
+}
+
+#endif  // FORTRAN_BURNSIDE_INTRINSICS_H_


### PR DESCRIPTION
The goal is to abstract which library is targeted while lowering the calls.
What matters in this commit is the exposed interface and the dynamic data structure that holds the runtime description.

The static description of the runtime used to feed this API is a dummy description. The long term goal is to share this knowledge with the folding code that uses runtime.