### PR TITLE
Removed mlir::ModuleManager from the bridge

### DIFF
--- a/lib/burnside/bridge.cc
+++ b/lib/burnside/bridge.cc
@@ -122,7 +122,7 @@ class FIRConverter {
   }
 
   M::FuncOp genFunctionFIR(llvm::StringRef callee, M::FunctionType funcTy) {
-    if (auto func{getNamedFunction(callee)}) {
+    if (auto func{getNamedFunction(getMod(), callee)}) {
       return func;
     }
     return createFunction(getMod(), callee, funcTy);
@@ -895,7 +895,7 @@ void FIRConverter::genFIR(AnalysisData &ad, std::list<Fl::Op> &operations) {
 template<typename A>
 void FIRConverter::translateRoutine(
     const A &routine, llvm::StringRef name, const Se::Symbol *funcSym) {
-  M::FuncOp func{getNamedFunction(name)};
+  M::FuncOp func{getNamedFunction(getMod(), name)};
   if (!func) {
     // get arguments and return type if any, otherwise just use empty vectors
     llvm::SmallVector<M::Type, 8> args;
@@ -960,10 +960,6 @@ void Br::BurnsideBridge::parseSourceFile(llvm::SourceMgr &srcMgr) {
   auto owningRef = M::parseSourceFile(srcMgr, context.get());
   module.reset(new M::ModuleOp(owningRef.get().getOperation()));
   owningRef.release();
-  if (validModule()) {
-    // symbols are added by ModuleManager ctor
-    manager.reset(new M::ModuleManager(getModule()));
-  }
 }
 
 Br::BurnsideBridge::BurnsideBridge(
@@ -973,7 +969,6 @@ Br::BurnsideBridge::BurnsideBridge(
   context = std::make_unique<M::MLIRContext>();
   module = std::make_unique<M::ModuleOp>(
       M::ModuleOp::create(M::UnknownLoc::get(context.get())));
-  manager = std::make_unique<M::ModuleManager>(getModule());
 }
 
 void Br::instantiateBurnsideBridge(

--- a/lib/burnside/bridge.h
+++ b/lib/burnside/bridge.h
@@ -52,7 +52,6 @@ public:
   }
 
   mlir::MLIRContext &getMLIRContext() { return *context.get(); }
-  mlir::ModuleManager &getManager() { return *manager.get(); }
   mlir::ModuleOp &getModule() { return *module.get(); }
 
   void parseSourceFile(llvm::SourceMgr &);
@@ -75,7 +74,6 @@ private:
   const parser::CookedSource *cooked;
   std::unique_ptr<mlir::MLIRContext> context;
   std::unique_ptr<mlir::ModuleOp> module;
-  std::unique_ptr<mlir::ModuleManager> manager;
 };
 
 /// Cross the bridge from the Fortran parse-tree, etc. to FIR+OpenMP+MLIR

--- a/lib/burnside/builder.cc
+++ b/lib/burnside/builder.cc
@@ -38,8 +38,8 @@ mlir::FuncOp B::createFunction(
   return func;
 }
 
-mlir::FuncOp B::getNamedFunction(llvm::StringRef name) {
-  return getBridge().getManager().lookupSymbol<mlir::FuncOp>(name);
+mlir::FuncOp B::getNamedFunction(mlir::ModuleOp module, llvm::StringRef name) {
+  return module.lookupSymbol<mlir::FuncOp>(name);
 }
 
 void B::SymMap::addSymbol(const semantics::Symbol *symbol, mlir::Value *value) {

--- a/lib/burnside/builder.h
+++ b/lib/burnside/builder.h
@@ -67,7 +67,7 @@ inline mlir::Block *createBlock(mlir::OpBuilder *bldr) {
 }
 
 /// Get a function by name (or null)
-mlir::FuncOp getNamedFunction(llvm::StringRef name);
+mlir::FuncOp getNamedFunction(mlir::ModuleOp, llvm::StringRef name);
 
 /// Create a new Function
 mlir::FuncOp createFunction(

--- a/lib/burnside/convert-expr.cc
+++ b/lib/burnside/convert-expr.cc
@@ -148,7 +148,7 @@ class ExprLowering {
 
   M::FuncOp getFunction(L::StringRef name, M::FunctionType funTy) {
     auto module{getModule(&builder)};
-    if (M::FuncOp func{getNamedFunction(name)}) {
+    if (M::FuncOp func{getNamedFunction(module, name)}) {
       return func;
     }
     return createFunction(module, name, funTy);

--- a/lib/burnside/intrinsics.cc
+++ b/lib/burnside/intrinsics.cc
@@ -71,7 +71,7 @@ std::optional<mlir::FuncOp> IntrinsicLibrary::getFunction(
   auto module{getModule(&builder)};
   if (const auto &it{lib.find({name, type})}; it != lib.end()) {
     const IntrinsicImplementation &impl{it->second};
-    if (mlir::FuncOp func{getNamedFunction(impl.symbol)}) {
+    if (mlir::FuncOp func{getNamedFunction(module, impl.symbol)}) {
       return func;
     }
     mlir::FuncOp function{createFunction(module, impl.symbol, impl.type)};


### PR DESCRIPTION
`mlir::ModuleManager` is not required anymore to hold the symbol table, `mlir::ModuleOp` can directly be used as to query symbols.

The `mlir::ModuleManager` is useful to create distinct temp names from a variable name, but it does not sync its symbol table automatically with the module it manages. Keeping a `ModuleManager`
in a high level context seems to be too risky.
For instance, there was currently a bug where function names were directly created in the Module but looked-up in the `ModuleManager` that could not find them.