### PR TITLE
Refactor intrinsic function lowering facility

### DIFF
--- a/lib/burnside/intrinsics.cc
+++ b/lib/burnside/intrinsics.cc
@@ -14,85 +14,421 @@
 
 #include "intrinsics.h"
 #include "builder.h"
+#include "fir/FIROps.h"
+#include <unordered_map>
+#include <utility>
 
 /// [Coding style](https://llvm.org/docs/CodingStandards.html)
 
 namespace Fortran::burnside {
 
-// Define a simple static runtime description that will be transformed into
-// IntrinsicImplementation when building the IntrinsicLibrary.
-namespace runtime {
-enum class Type { f32, f64 };
-struct StaticDescription {
-  const char *name;
-  const char *symbol;
-  Type resultType;
-  std::vector<Type> argumentTypes;
+/// MathRuntimeLibrary maps Fortran generic intrinsic names to runtime function
+/// signatures. There is no guarantee that that runtime functions are available
+/// for all intrinsic functions and possible types.
+/// To be easy and fast to use, this class holds a map and uses
+/// mlir::FunctionType to represent the runtime function type. This imply that
+/// MathRuntimeLibrary cannot be constexpr built and requires an
+/// mlir::MLIRContext to be built. Its constructor uses a constexpr table
+/// description of the runtime. The runtime functions are not declared into the
+/// mlir::module until there is a query that needs them. This is to avoid
+/// polluting the FIR/LLVM IR dumps with unused functions.
+class MathRuntimeLibrary {
+public:
+  /// The map key are Fortran generic intrinsic names.
+  using Key = llvm::StringRef;
+  struct Hash {  // Need custom hash for this kind of key
+    size_t operator()(const Key &k) const { return llvm::hash_value(k); }
+  };
+  /// Runtime function description that is sufficient to build an
+  /// mlir::FuncOp and to compare function types.
+  struct RuntimeFunction {
+    RuntimeFunction(llvm::StringRef n, mlir::FunctionType t)
+      : symbol{n}, type{t} {};
+    llvm::StringRef symbol;
+    mlir::FunctionType type;
+  };
+  using Map = std::unordered_multimap<Key, RuntimeFunction, Hash>;
+
+  MathRuntimeLibrary(IntrinsicLibrary::Version, mlir::MLIRContext &);
+
+  /// Probe the intrinsic library for a certain intrinsic and get/build the
+  /// related mlir::FuncOp if a runtime description is found.
+  /// Also add a unit attribute "fir.runtime" to the function so that later
+  /// it is possible to quickly know what function are intrinsics vs users.
+  std::optional<mlir::FuncOp> getFunction(
+      mlir::OpBuilder &, llvm::StringRef, mlir::FunctionType) const;
+
+private:
+  mlir::FuncOp getFuncOp(
+      mlir::OpBuilder &builder, const RuntimeFunction &runtime) const;
+  Map library;
 };
 
-// TODO
-// This table should be generated in a clever ways and probably shared with
-// lib/evaluate intrinsic folding.
-static const StaticDescription llvm[] = {
-    {"abs", "llvm.fabs.f32", Type::f32, {Type::f32}},
-    {"abs", "llvm.fabs.f64", Type::f64, {Type::f64}},
-    {"acos", "acosf", Type::f32, {Type::f32}},
-    {"acos", "acos", Type::f64, {Type::f64}},
-    {"atan", "atan2f", Type::f32, {Type::f32, Type::f32}},
-    {"atan", "atan2", Type::f64, {Type::f64, Type::f64}},
-    {"sqrt", "llvm.sqrt.f32", Type::f32, {Type::f32}},
-    {"sqrt", "llvm.sqrt.f64", Type::f64, {Type::f64}},
-    {"cos", "llvm.cos.f32", Type::f32, {Type::f32}},
-    {"cos", "llvm.cos.f64", Type::f64, {Type::f64}},
-    {"sin", "llvm.sin.f32", Type::f32, {Type::f32}},
-    {"sin", "llvm.sin.f64", Type::f64, {Type::f64}},
+/// The implementation of IntrinsicLibrary is based on a map that associates
+/// Fortran intrinsics generic names to the related FIR generator functions.
+/// All generator functions are member functions of the Implementation class
+/// and they all take the same context argument that contains the name and
+/// arguments of the Fortran intrinsics call to lower among other things.
+/// A same FIR generator function may be able to generate the FIR for several
+/// intrinsics. For instance generateRuntimeCall tries to find a runtime
+/// functions that matches the Fortran intrinsic call and generate the
+/// operations to call this functions if it was found.
+/// IntrinsicLibrary holds a constant MathRuntimeLibrary that it uses to
+/// find and place call to math runtime functions. This library is built
+/// when the Implementation is built. Because of this, Implementation is
+/// not cheap to build and it should be kept as long as possible.
+
+// TODO it is unclear how optional argument are handled
+// TODO error handling -> return a code or directly emit messages ?
+class IntrinsicLibrary::Implementation {
+public:
+  Implementation(Version v, mlir::MLIRContext &c) : runtime{v, c} {}
+  inline mlir::Value *genval(mlir::Location loc, mlir::OpBuilder &builder,
+      llvm::StringRef name, mlir::Type resultType,
+      llvm::ArrayRef<mlir::Value *> args) const;
+
+private:
+  // Info needed by Generators is passed in Context struct to keep Generator
+  // signatures modification easy.
+  struct Context {
+    mlir::Location loc;
+    mlir::OpBuilder *builder{nullptr};
+    llvm::StringRef name;
+    mlir::Type resultType;
+    llvm::ArrayRef<mlir::Value *> arguments;
+    mlir::FunctionType funcType;
+  };
+
+  /// Define the different FIR generators that can be mapped to intrinsic to
+  /// generate the related code.
+  using Generator = mlir::Value *(Implementation::*)(Context &)const;
+  /// Search a runtime function that is associated to the generic intrinsic name
+  /// and whose signature matches the intrinsic arguments and result types.
+  /// If no such runtime function is found but a runtime function associated
+  /// with the Fortran generic exists and has the same number of arguments,
+  /// conversions will be inserted before and/or after the call. This is to
+  /// mainly to allow 16 bits float support even-though little or no math
+  /// runtime is currently available for it.
+  mlir::Value *generateRuntimeCall(Context &) const;
+  /// All generators can be combined with generateWrapperCall that will build a
+  /// function named "fir."+ <generic name> + "." + <result type code> and
+  /// generate the intrinsic implementation inside instead of at the intrinsic
+  /// call sites. This can be used to keep the FIR more readable.
+  template<Generator g> mlir::Value *generateWrapperCall(Context &c) const {
+    return outlineInWrapper(g, c);
+  }
+  /// The defaultGenerator is always attempted if no mapping was found for the
+  /// generic name provided.
+  mlir::Value *defaultGenerator(Context &c) const {
+    return generateWrapperCall<&I::generateRuntimeCall>(c);
+  }
+
+  struct IntrinsicHanlder {
+    const char *name;
+    Generator generator{&I::defaultGenerator};
+  };
+  using I = Implementation;
+  /// Table that drives the fir generation depending on the intrinsic.
+  /// one to one mapping with Fortran arguments. If no mapping is
+  /// defined here for a generic intrinsic, the defaultGenerator will
+  /// be attempted.
+  static constexpr IntrinsicHanlder handlers[]{
+      {"abs", &I::defaultGenerator},
+      {"acos", &I::defaultGenerator},
+      {"atan", &I::defaultGenerator},
+      {"sqrt", &I::defaultGenerator},
+      {"cos", &I::defaultGenerator},
+      {"sin", &I::defaultGenerator},
+  };
+
+  // helpers
+  static std::string getWrapperName(Context &);
+  mlir::Value *outlineInWrapper(Generator, Context &) const;
+  static mlir::FunctionType getFunctionType(mlir::Type resultType,
+      llvm::ArrayRef<mlir::Value *> arguments, mlir::OpBuilder &);
+
+  MathRuntimeLibrary runtime;
 };
 
-// Conversion between types of the static representation and MLIR types.
-mlir::Type toMLIRType(Type t, mlir::MLIRContext &context) {
-  switch (t) {
-  case Type::f32: return mlir::FloatType::getF32(&context);
-  case Type::f64: return mlir::FloatType::getF64(&context);
-  }
-}
-mlir::FunctionType toMLIRFunctionType(
-    const StaticDescription &func, mlir::MLIRContext &context) {
-  std::vector<mlir::Type> argMLIRTypes;
-  for (runtime::Type t : func.argumentTypes) {
-    argMLIRTypes.push_back(toMLIRType(t, context));
-  }
-  return mlir::FunctionType::get(
-      argMLIRTypes, toMLIRType(func.resultType, context), &context);
-}
-}  // runtime
-
-std::optional<mlir::FuncOp> IntrinsicLibrary::getFunction(
-    llvm::StringRef name, mlir::Type type, mlir::OpBuilder &builder) const {
-  auto module{getModule(&builder)};
-  if (const auto &it{lib.find({name, type})}; it != lib.end()) {
-    const IntrinsicImplementation &impl{it->second};
-    if (mlir::FuncOp func{getNamedFunction(module, impl.symbol)}) {
-      return func;
+/// Define a simple static runtime description that will be transformed into
+/// RuntimeFunction when building the IntrinsicLibrary.
+/// It is constexpr constructible so that static tables of such descriptions can
+/// be safely stored as global variables without requiring global constructors.
+class RuntimeStaticDescription {
+public:
+  /// Define possible runtime function argument/return type used in signature
+  /// descriptions. They follow mlir standard types naming. MLIR types cannot
+  /// directly be used because they can only be dynamically built.
+  enum class Type { f32, f64 };
+  /// C++ does not provide variable size constexpr container yet. TypeVector
+  /// implements one for Type elements. It works because Type is an enumeration.
+  struct TypeVector {
+    template<Type... v> struct Storage {
+      static constexpr Type values[]{v...};
+    };
+    template<Type... v> static constexpr TypeVector create() {
+      const Type *start{&Storage<v...>::values[0]};
+      return TypeVector{start, start + sizeof...(v)};
     }
-    mlir::FuncOp function{createFunction(module, impl.symbol, impl.type)};
-    function.setAttr("fir.intrinsic", builder.getUnitAttr());
-    return function;
+    const Type *start{nullptr};
+    const Type *end{nullptr};
+  };
+  constexpr RuntimeStaticDescription(
+      const char *n, const char *s, Type r, TypeVector a)
+    : name{n}, symbol{s}, resultType{r}, argumentTypes{a} {}
+  llvm::StringRef getSymbol() const { return symbol; }
+  llvm::StringRef getName() const { return name; }
+  /// Conversion between types of the static representation and MLIR types.
+  mlir::FunctionType getMLIRFunctionType(mlir::MLIRContext &) const;
+
+private:
+  static mlir::Type getMLIRType(Type, mlir::MLIRContext &);
+
+  const char *name{nullptr};
+  const char *symbol{nullptr};
+  Type resultType;
+  TypeVector argumentTypes;
+};
+
+/// Description of the runtime functions available on the target.
+using RType = typename RuntimeStaticDescription::Type;
+using Args = typename RuntimeStaticDescription::TypeVector;
+static constexpr RuntimeStaticDescription llvmRuntime[] = {
+    {"abs", "llvm.fabs.f32", RType::f32, Args::create<RType::f32>()},
+    {"abs", "llvm.fabs.f64", RType::f64, Args::create<RType::f64>()},
+    {"acos", "acosf", RType::f32, Args::create<RType::f32>()},
+    {"acos", "acos", RType::f64, Args::create<RType::f64>()},
+    {"atan", "atan2f", RType::f32, Args::create<RType::f32, RType::f32>()},
+    {"atan", "atan2", RType::f64, Args::create<RType::f64, RType::f64>()},
+    {"sqrt", "llvm.sqrt.f32", RType::f32, Args::create<RType::f32>()},
+    {"sqrt", "llvm.sqrt.f64", RType::f64, Args::create<RType::f64>()},
+    {"cos", "llvm.cos.f32", RType::f32, Args::create<RType::f32>()},
+    {"cos", "llvm.cos.f64", RType::f64, Args::create<RType::f64>()},
+    {"sin", "llvm.sin.f32", RType::f32, Args::create<RType::f32>()},
+    {"sin", "llvm.sin.f64", RType::f64, Args::create<RType::f64>()},
+};
+// TODO : This table should be generated in a clever ways and probably shared
+// with lib/evaluate intrinsic folding.
+
+// Implementations
+
+// IntrinsicLibrary implementation
+
+IntrinsicLibrary IntrinsicLibrary::create(
+    IntrinsicLibrary::Version v, mlir::MLIRContext &context) {
+  IntrinsicLibrary lib{};
+  lib.impl = new Implementation(v, context);
+  return lib;
+}
+
+IntrinsicLibrary::~IntrinsicLibrary() { delete impl; }
+
+mlir::Value *IntrinsicLibrary::genval(mlir::Location loc,
+    mlir::OpBuilder &builder, llvm::StringRef name, mlir::Type resultType,
+    llvm::ArrayRef<mlir::Value *> args) const {
+  assert(impl);
+  return impl->genval(loc, builder, name, resultType, args);
+}
+
+// MathRuntimeLibrary implementation
+
+// Create the runtime description for the targeted library version.
+// So far ignore the version an only load the dummy llvm lib.
+MathRuntimeLibrary::MathRuntimeLibrary(
+    IntrinsicLibrary::Version, mlir::MLIRContext &context) {
+  for (const RuntimeStaticDescription &func : llvmRuntime) {
+    Key key{func.getName()};
+    RuntimeFunction impl{func.getSymbol(), func.getMLIRFunctionType(context)};
+    library.insert({key, impl});
+  }
+}
+
+mlir::FuncOp MathRuntimeLibrary::getFuncOp(
+    mlir::OpBuilder &builder, const RuntimeFunction &runtime) const {
+  auto module{getModule(&builder)};
+  mlir::FuncOp function{getNamedFunction(module, runtime.symbol)};
+  if (!function) {
+    function = createFunction(module, runtime.symbol, runtime.type);
+    function.setAttr("fir.runtime", builder.getUnitAttr());
+  }
+  return function;
+}
+
+std::optional<mlir::FuncOp> MathRuntimeLibrary::getFunction(
+    mlir::OpBuilder &builder, llvm::StringRef name,
+    mlir::FunctionType funcType) const {
+  auto range{library.equal_range(name)};
+  const RuntimeFunction *bestNearMatch{nullptr};
+  for (auto iter{range.first}; iter != range.second; ++iter) {
+    const RuntimeFunction &impl{iter->second};
+    if (funcType == impl.type) {
+      return getFuncOp(builder, impl);  // exact match
+    } else {
+      if (!bestNearMatch &&
+          impl.type.getNumResults() == funcType.getNumResults() &&
+          impl.type.getNumInputs() == funcType.getNumInputs()) {
+        bestNearMatch = &impl;
+      } else {
+        // TODO the best near match should not be the first hit.
+        // It should apply rules:
+        //  -> Non narrowing argument conversion are better
+        //  -> The "nearest" conversions are better
+      }
+    }
+  }
+  if (bestNearMatch != nullptr) {
+    return getFuncOp(builder, *bestNearMatch);
   } else {
     return std::nullopt;
   }
 }
 
-// So far ignore the version an only load the dummy llvm lib.
-IntrinsicLibrary IntrinsicLibrary::create(
-    IntrinsicLibrary::Version, mlir::MLIRContext &context) {
-  Map map;
-  for (const auto &func : runtime::llvm) {
-    IntrinsicLibrary::Key key{
-        func.name, runtime::toMLIRType(func.resultType, context)};
-    IntrinsicImplementation impl{
-        func.symbol, runtime::toMLIRFunctionType(func, context)};
-    map.insert({key, impl});
+// IntrinsicLibrary::Implementation implementation
+
+mlir::Value *IntrinsicLibrary::Implementation::genval(mlir::Location loc,
+    mlir::OpBuilder &builder, llvm::StringRef name, mlir::Type resultType,
+    llvm::ArrayRef<mlir::Value *> args) const {
+  Context context{loc, &builder, name, resultType, args,
+      getFunctionType(resultType, args, builder)};
+  for (const IntrinsicHanlder &handler : handlers) {
+    if (name == handler.name) {
+      assert(handler.generator != nullptr);
+      return (this->*handler.generator)(context);
+    }
   }
-  return IntrinsicLibrary{std::move(map)};
+  // Try the default generator if no special handler was defined for the
+  // intrinsic being called.
+  return this->defaultGenerator(context);
 }
+
+mlir::FunctionType IntrinsicLibrary::Implementation::getFunctionType(
+    mlir::Type resultType, llvm::ArrayRef<mlir::Value *> arguments,
+    mlir::OpBuilder &builder) {
+  llvm::SmallVector<mlir::Type, 2> argumentTypes;
+  for (const auto &arg : arguments) {
+    assert(arg != nullptr);  // TODO think about optionals
+    argumentTypes.push_back(arg->getType());
+  }
+  return mlir::FunctionType::get(
+      argumentTypes, resultType, getModule(&builder).getContext());
+}
+
+std::string IntrinsicLibrary::Implementation::getWrapperName(Context &c) {
+  // TODO find nicer type to string infra
+  llvm::StringRef typeName{"unknown"};
+  if (c.resultType.isF16()) {
+    typeName = "f16";
+  } else if (c.resultType.isF32()) {
+    typeName = "f32";
+  } else if (c.resultType.isF64()) {
+    typeName = "f64";
+  } else {
+    assert(false);
+  }
+  return "fir." + c.name.str() + "." + typeName.str();
+}
+
+mlir::Value *IntrinsicLibrary::Implementation::outlineInWrapper(
+    Generator generator, Context &context) const {
+  mlir::ModuleOp module{getModule(context.builder)};
+  mlir::MLIRContext *mlirContext{module.getContext()};
+  std::string wrapperName{getWrapperName(context)};
+  mlir::FuncOp function{getNamedFunction(module, wrapperName)};
+  if (!function) {
+    // First time this wrapper is needed, build it.
+    function = createFunction(module, wrapperName, context.funcType);
+    function.setAttr("fir.intrinsic", context.builder->getUnitAttr());
+    function.addEntryBlock();
+
+    // Create local context to emit code into the newly created function
+    // This new function is not linked to a source file location, only
+    // its calls will be.
+    Context localContext{context};
+    auto localBuilder{std::make_unique<mlir::OpBuilder>(function)};
+    localBuilder->setInsertionPointToStart(&function.front());
+    localContext.builder = &(*localBuilder);
+    llvm::SmallVector<mlir::Value *, 2> localArguments;
+    for (mlir::BlockArgument *bArg : function.front().getArguments()) {
+      localArguments.push_back(bArg);
+    }
+    localContext.arguments = localArguments;
+    localContext.loc = mlir::UnknownLoc::get(mlirContext);
+
+    mlir::Value *result{(this->*generator)(localContext)};
+    localBuilder->create<mlir::ReturnOp>(localContext.loc, result);
+  } else {
+    // Wrapper was already built, ensure it has the sought type
+    assert(function.getType() == context.funcType);
+  }
+  auto call{context.builder->create<mlir::CallOp>(
+      context.loc, function, context.arguments)};
+  return call.getResult(0);
+}
+
+mlir::Value *IntrinsicLibrary::Implementation::generateRuntimeCall(
+    Context &context) const {
+  // Look up runtime
+  mlir::FunctionType soughtFuncType{context.funcType};
+  if (auto funcOp{runtime.getFunction(
+          *context.builder, context.name, soughtFuncType)}) {
+    mlir::FunctionType actualFuncType{funcOp->getType()};
+    if (actualFuncType.getNumResults() != soughtFuncType.getNumResults() ||
+        actualFuncType.getNumInputs() != soughtFuncType.getNumInputs() ||
+        actualFuncType.getNumInputs() != context.arguments.size() ||
+        actualFuncType.getNumResults() != 1) {
+      assert(false);  // TODO better error handling
+      return nullptr;
+    }
+    llvm::SmallVector<mlir::Value *, 2> convertedArguments;
+    int i{0};
+    for (mlir::Value *arg : context.arguments) {
+      mlir::Type actualType{actualFuncType.getInput(i)};
+      if (soughtFuncType.getInput(i) != actualType) {
+        auto castedArg{context.builder->create<fir::ConvertOp>(
+            context.loc, actualType, arg)};
+        convertedArguments.push_back(castedArg.getResult());
+      } else {
+        convertedArguments.push_back(arg);
+      }
+      ++i;
+    }
+    auto call{context.builder->create<mlir::CallOp>(
+        context.loc, *funcOp, convertedArguments)};
+    mlir::Type soughtType{soughtFuncType.getResult(0)};
+    mlir::Value *res{call.getResult(0)};
+    if (actualFuncType.getResult(0) != soughtType) {
+      auto castedRes{context.builder->create<fir::ConvertOp>(
+          context.loc, soughtType, res)};
+      return castedRes.getResult();
+    } else {
+      return res;
+    }
+  } else {
+    // could not find runtime function
+    assert(false);  // TODO: better error handling.
+    return nullptr;
+  }
+}
+
+// RuntimeStaticDescription implementation
+
+mlir::Type RuntimeStaticDescription::getMLIRType(
+    Type t, mlir::MLIRContext &context) {
+  switch (t) {
+  case Type::f32: return mlir::FloatType::getF32(&context);
+  case Type::f64: return mlir::FloatType::getF64(&context);
+  }
+}
+
+mlir::FunctionType RuntimeStaticDescription::getMLIRFunctionType(
+    mlir::MLIRContext &context) const {
+  llvm::SmallVector<mlir::Type, 2> argMLIRTypes;
+  for (const Type *t{argumentTypes.start};
+       t != nullptr && t != argumentTypes.end; ++t) {
+    argMLIRTypes.push_back(getMLIRType(*t, context));
+  }
+  mlir::Type resMLIRType{getMLIRType(resultType, context)};
+  return mlir::FunctionType::get(argMLIRTypes, resMLIRType, &context);
+}
+
 }


### PR DESCRIPTION
+ Add a level of indirection in front of the facility describing runtime functions related to Fortran intrinsic functions. This level allows to select a code generation function depending on the generic intrinsic name. This is because not all Fortran intrinsic functions map to runtime functions and even when they do, they may not map one to one and may require generating some boilerplate.

+ Completely hide the implementation using an owning pointer. It did not bring anything to define implementation related class in the header. So only expose a simple interface.

+ All code implementation code is reorganized in three classes:
 -> `RuntimeStaticDescription`: allows constexpr description of the runtime libraries.
 -> `MathRuntimeLibrary`: maps a reified representation of runtime functions to generic
    intrinsic names. It is dynamically built from RuntimeStaticDescription.
 -> `IntrinsicLibrary::Implementation`: define functions to generate FIR+MLIR for intrinsic functions. Defines a dispatch table between generic names and such generator functions. Holds a MathRuntimeLibrary to allow generator function to generate runtime calls.

+ Get rid of non constexpr global objects and make IntrinsicLibrary immutable once it is built. This is to harden this utility for use in multi-threaded contexts.

+ Add the possibility to generate FIR+MLIR code for intrinsic calls inside wrappers to keep the code readable and also keep better track of Fortran intrinsics which may be useful/necessary in future optimization passes.