### PR TITLE
Jpr more expr

### DIFF
--- a/include/fir/FIROps.td
+++ b/include/fir/FIROps.td
@@ -420,6 +420,32 @@ def fir_FreeMemOp : fir_Op<"freemem", []>,
   }];
 }
 
+def fir_ComplexZipOp : fir_SimpleOp<"czip", [NoSideEffect]>,
+    Results<(outs fir_ComplexType:$complex)>,
+    Arguments<(ins AnyRealLike:$real, AnyRealLike:$imag)> {
+  let summary = "Construct a complex from two reals";
+
+  let description = [{
+    Return a `fir.complex` of from the real an imaginary parts.
+    The two real argument must have the same kind and the complex kind is the
+    one of the real parts.
+  }];
+  // SimpleOp printer seems to only print one arg
+  let printer = [{
+    return fir::printComplexBinaryOp(this->getOperation(), p);
+  }];
+}
+
+def fir_ComplexUnzipOp : fir_SimpleOp<"cunzip", [NoSideEffect]>,
+    Results<(outs AnyRealLike:$real, AnyRealLike:$imag)>,
+    Arguments<(ins fir_ComplexType:$complex)> {
+  let summary = "Extract the real and imaginary part from a complex";
+
+  let description = [{
+    Return two reals that are the real and imaginary part of the argument.
+  }];
+}
+
 // Terminator operations
 
 class fir_SwitchTerminatorOp<string mnemonic, list<OpTrait> traits = []> :
@@ -1642,6 +1668,7 @@ def fir_SubfOp : RealArithmeticOp<"subf">;
 def fir_MulfOp : RealArithmeticOp<"mulf", [Commutative]>;
 def fir_DivfOp : RealArithmeticOp<"divf">;
 def fir_ModfOp : RealArithmeticOp<"modf">;
+
 
 class ComplexArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
       fir_ArithmeticOp<mnemonic, traits>,

--- a/include/fir/Type.h
+++ b/include/fir/Type.h
@@ -90,8 +90,16 @@ class CharacterType
 public:
   using Base::Base;
   static CharacterType get(mlir::MLIRContext *ctxt, KindTy kind);
-  int getSizeInBits() const;
-  KindTy getFKind() const { return getSizeInBits() / 8; }
+  KindTy getFKind() const;
+};
+
+class CplxType : public mlir::Type::TypeBase<CplxType, mlir::Type,
+                                             detail::CplxTypeStorage>,
+                 public IntrinsicTypeMixin<CplxType, TypeKind::FIR_COMPLEX> {
+public:
+  using Base::Base;
+  static CplxType get(mlir::MLIRContext *ctxt, KindTy kind);
+  KindTy getFKind() const;
 };
 
 class IntType
@@ -100,8 +108,7 @@ class IntType
 public:
   using Base::Base;
   static IntType get(mlir::MLIRContext *ctxt, KindTy kind);
-  int getSizeInBits() const;
-  KindTy getFKind() const { return getSizeInBits() / 8; }
+  KindTy getFKind() const;
 };
 
 class LogicalType
@@ -111,8 +118,7 @@ class LogicalType
 public:
   using Base::Base;
   static LogicalType get(mlir::MLIRContext *ctxt, KindTy kind);
-  int getSizeInBits() const;
-  KindTy getFKind() const { return getSizeInBits() / 8; }
+  KindTy getFKind() const;
 };
 
 class RealType : public mlir::Type::TypeBase<RealType, mlir::Type,
@@ -121,17 +127,6 @@ class RealType : public mlir::Type::TypeBase<RealType, mlir::Type,
 public:
   using Base::Base;
   static RealType get(mlir::MLIRContext *ctxt, KindTy kind);
-  int getSizeInBits() const;
-  KindTy getFKind() const { return getSizeInBits() / 8; }
-};
-
-class CplxType : public mlir::Type::TypeBase<CplxType, mlir::Type,
-                                             detail::CplxTypeStorage>,
-                 public IntrinsicTypeMixin<CplxType, TypeKind::FIR_COMPLEX> {
-public:
-  using Base::Base;
-  static CplxType get(mlir::MLIRContext *ctxt, KindTy kind);
-  int getSizeInBits() const;
   KindTy getFKind() const;
 };
 

--- a/lib/fir/StdConverter.cpp
+++ b/lib/fir/StdConverter.cpp
@@ -52,7 +52,7 @@ using AttributeTy = L::ArrayRef<M::NamedAttribute>;
 /// This converts a subset of FIR types to standard types
 class FIRToStdTypeConverter : public M::TypeConverter {
 public:
-  explicit FIRToStdTypeConverter() {}
+  using TypeConverter::TypeConverter;
 
   // convert a front-end kind value to either a std dialect type
   static M::Type kindToRealType(M::MLIRContext *ctx, KindTy kind) {
@@ -69,14 +69,14 @@ public:
     return fir::RealType::get(ctx, kind);
   }
 
-  /// Convert FIR types to LLVM IR dialect types
+  /// Convert FIR types to MLIR standard dialect types
   M::Type convertType(M::Type t) override {
     if (auto cplx = t.dyn_cast<CplxType>()) {
       return M::ComplexType::get(
           kindToRealType(cplx.getContext(), cplx.getFKind()));
     }
     if (auto integer = t.dyn_cast<IntType>()) {
-      return M::IntegerType::get(integer.getSizeInBits(), integer.getContext());
+      return M::IntegerType::get(integer.getFKind() * 8, integer.getContext());
     }
     if (auto real = t.dyn_cast<RealType>()) {
       return kindToRealType(real.getContext(), real.getFKind());

--- a/lib/fir/Tilikum.cpp
+++ b/lib/fir/Tilikum.cpp
@@ -392,7 +392,7 @@ struct BoxDimsOpConversion : public FIROpConversion<BoxDimsOp> {
     auto c7attr = M::ArrayAttr::get(rewriter.getI32IntegerAttr(7), ctx);
     auto c7 = rewriter.create<M::LLVM::ConstantOp>(loc, ity, c7attr);
     auto ty = lowering.convertType(boxdims.getResult(0)->getType());
-    L::SmallVector<M::Value*, 4> args({a, c0, c7, dim});
+    L::SmallVector<M::Value *, 4> args({a, c0, c7, dim});
     auto p = rewriter.create<M::LLVM::GEPOp>(loc, ty, args);
     rewriter.replaceOpWithNewOp<M::LLVM::LoadOp>(boxdims, ty, p);
     return matchSuccess();
@@ -483,13 +483,11 @@ struct BoxProcHostOpConversion : public FIROpConversion<BoxProcHostOp> {
                   M::ConversionPatternRewriter &rewriter) const override {
     auto boxprochost = M::cast<BoxProcHostOp>(op);
     auto a = operands[0];
-    auto loc = boxprochost.getLoc();
     auto ty = lowering.convertType(boxprochost.getType());
     auto ctx = boxprochost.getContext();
     auto c1 = M::ArrayAttr::get(rewriter.getI32IntegerAttr(1), ctx);
-    auto r = rewriter.create<M::LLVM::ExtractValueOp>(loc, ty, a, c1);
-    boxprochost.replaceAllUsesWith(r.getResult());
-    rewriter.replaceOp(boxprochost, r.getResult());
+    rewriter.replaceOpWithNewOp<M::LLVM::ExtractValueOp>(boxprochost, ty, a,
+                                                         c1);
     return matchSuccess();
   }
 };
@@ -502,13 +500,10 @@ struct BoxRankOpConversion : public FIROpConversion<BoxRankOp> {
                   M::ConversionPatternRewriter &rewriter) const override {
     auto boxrank = M::cast<BoxRankOp>(op);
     auto a = operands[0];
-    auto loc = boxrank.getLoc();
     auto ty = lowering.convertType(boxrank.getType());
     auto ctx = boxrank.getContext();
     auto c3 = M::ArrayAttr::get(rewriter.getI32IntegerAttr(3), ctx);
-    auto r = rewriter.create<M::LLVM::ExtractValueOp>(loc, ty, a, c3);
-    boxrank.replaceAllUsesWith(r.getResult());
-    rewriter.replaceOp(boxrank, r.getResult());
+    rewriter.replaceOpWithNewOp<M::LLVM::ExtractValueOp>(boxrank, ty, a, c3);
     return matchSuccess();
   }
 };
@@ -677,10 +672,9 @@ struct EmboxCharOpConversion : public FIROpConversion<EmboxCharOp> {
     auto c0 = M::ArrayAttr::get(rewriter.getI32IntegerAttr(0), ctx);
     auto c1 = M::ArrayAttr::get(rewriter.getI32IntegerAttr(1), ctx);
     auto un = rewriter.create<M::LLVM::UndefOp>(loc, ty);
-    auto r_ = rewriter.create<M::LLVM::InsertValueOp>(loc, ty, un, a, c0);
-    auto r = rewriter.create<M::LLVM::InsertValueOp>(loc, ty, r_, b, c1);
-    emboxchar.replaceAllUsesWith(r.getResult());
-    rewriter.replaceOp(emboxchar, r.getResult());
+    auto r = rewriter.create<M::LLVM::InsertValueOp>(loc, ty, un, a, c0);
+    rewriter.replaceOpWithNewOp<M::LLVM::InsertValueOp>(emboxchar, ty, r, b,
+                                                        c1);
     return matchSuccess();
   }
 };
@@ -714,10 +708,9 @@ struct EmboxProcOpConversion : public FIROpConversion<EmboxProcOp> {
     auto c0 = M::ArrayAttr::get(rewriter.getI32IntegerAttr(0), ctx);
     auto c1 = M::ArrayAttr::get(rewriter.getI32IntegerAttr(1), ctx);
     auto un = rewriter.create<M::LLVM::UndefOp>(loc, ty);
-    auto r_ = rewriter.create<M::LLVM::InsertValueOp>(loc, ty, un, a, c0);
-    auto r = rewriter.create<M::LLVM::InsertValueOp>(loc, ty, r_, b, c1);
-    emboxproc.replaceAllUsesWith(r.getResult());
-    rewriter.replaceOp(emboxproc, r.getResult());
+    auto r = rewriter.create<M::LLVM::InsertValueOp>(loc, ty, un, a, c0);
+    rewriter.replaceOpWithNewOp<M::LLVM::InsertValueOp>(emboxproc, ty, r, b,
+                                                        c1);
     return matchSuccess();
   }
 };
@@ -1060,9 +1053,8 @@ struct UndefOpConversion : public FIROpConversion<UndefOp> {
   matchAndRewrite(M::Operation *op, OperandTy operands,
                   M::ConversionPatternRewriter &rewriter) const override {
     auto undef = M::cast<UndefOp>(op);
-    M::Value *v{rewriter.create<M::LLVM::UndefOp>(
-        undef.getLoc(), lowering.convertType(undef.getType()))};
-    rewriter.replaceOp(op, v);
+    rewriter.replaceOpWithNewOp<M::LLVM::UndefOp>(
+        undef, lowering.convertType(undef.getType()));
     return matchSuccess();
   }
 };
@@ -1074,10 +1066,11 @@ struct UnreachableOpConversion : public FIROpConversion<UnreachableOp> {
   M::PatternMatchResult
   matchAndRewrite(M::Operation *op, OperandTy operands,
                   M::ConversionPatternRewriter &rewriter) const override {
+    auto unreach = M::cast<UnreachableOp>(op);
     L::SmallVector<M::Block *, 1> destinations; // none
     L::SmallVector<OperandTy, 1> destOperands;  // none
-    rewriter.create<M::LLVM::UnreachableOp>(
-        op->getLoc(), operands, destinations, destOperands, op->getAttrs());
+    rewriter.replaceOpWithNewOp<M::LLVM::UnreachableOp>(
+        unreach, operands, destinations, destOperands, unreach.getAttrs());
     return matchSuccess();
   }
 };

--- a/lib/fir/Type.cpp
+++ b/lib/fir/Type.cpp
@@ -1231,10 +1231,10 @@ bool fir::isa_fir_or_std_type(mlir::Type t) {
 // CHARACTER
 
 CharacterType fir::CharacterType::get(M::MLIRContext *ctxt, KindTy kind) {
-  return Base::get(ctxt, FIR_CHARACTER, kind * 8);
+  return Base::get(ctxt, FIR_CHARACTER, kind);
 }
 
-int fir::CharacterType::getSizeInBits() const { return getImpl()->getFKind(); }
+int fir::CharacterType::getFKind() const { return getImpl()->getFKind(); }
 
 // Dims
 
@@ -1253,35 +1253,34 @@ FieldType fir::FieldType::get(M::MLIRContext *ctxt, KindTy) {
 // LOGICAL
 
 LogicalType fir::LogicalType::get(M::MLIRContext *ctxt, KindTy kind) {
-  return Base::get(ctxt, FIR_LOGICAL, kind * 8);
+  return Base::get(ctxt, FIR_LOGICAL, kind);
 }
 
-int fir::LogicalType::getSizeInBits() const { return getImpl()->getFKind(); }
+int fir::LogicalType::getFKind() const { return getImpl()->getFKind(); }
 
 // INTEGER
 
 IntType fir::IntType::get(M::MLIRContext *ctxt, KindTy kind) {
-  return Base::get(ctxt, FIR_INT, kind * 8);
+  return Base::get(ctxt, FIR_INT, kind);
 }
 
-int fir::IntType::getSizeInBits() const { return getImpl()->getFKind(); }
+int fir::IntType::getFKind() const { return getImpl()->getFKind(); }
 
 // COMPLEX
 
 CplxType fir::CplxType::get(M::MLIRContext *ctxt, KindTy kind) {
-  return Base::get(ctxt, FIR_COMPLEX, kind * 8);
+  return Base::get(ctxt, FIR_COMPLEX, kind);
 }
 
-int fir::CplxType::getSizeInBits() const { return getImpl()->getFKind() * 2; }
-KindTy fir::CplxType::getFKind() const { return getImpl()->getFKind() / 8; }
+KindTy fir::CplxType::getFKind() const { return getImpl()->getFKind(); }
 
 // REAL
 
 RealType fir::RealType::get(M::MLIRContext *ctxt, KindTy kind) {
-  return Base::get(ctxt, FIR_REAL, kind * 8);
+  return Base::get(ctxt, FIR_REAL, kind);
 }
 
-int fir::RealType::getSizeInBits() const { return getImpl()->getFKind(); }
+int fir::RealType::getFKind() const { return getImpl()->getFKind(); }
 
 // Box<T>
 
@@ -1306,7 +1305,7 @@ fir::BoxType::verifyConstructionInvariants(L::Optional<M::Location>,
 // BoxChar<C>
 
 BoxCharType fir::BoxCharType::get(M::MLIRContext *ctxt, KindTy kind) {
-  return Base::get(ctxt, FIR_BOXCHAR, kind * 8);
+  return Base::get(ctxt, FIR_BOXCHAR, kind);
 }
 
 CharacterType fir::BoxCharType::getEleTy() const {


### PR DESCRIPTION
- Added fir complex zip and unzip operations (forgot to discuss this yesterday)
     - Define ComplexZipOp and ComplexUnzipOp in FIROps.td. They are required to lower ComplexConstructor and ComplexPart expression from lib/evaluate. Also, they seems a useful feature to access complex parts. I just made it so that I could work, you may want to redefine/rename them.
     - Also implement them in Tilikum. That was not that useful for me, but I am not really used to defining mlir ops, so I wanted to make sure I was getting this correctly enough so that it was possible to use them end-to-end.

- Lowering more complex expr to fir:   
    -  Implement **, +, -, / operation lowering.
    - Also implement "conjg" intrinsic lowering.
    - Lower evaluate::ComplexConstructor and evaluate::ComplexPart to the
    - previously defined fir::ComplexZipOp and fir::ComplexUnzipOp.
    - Add Complex constant handling.

On thing that I need to improve on Complex handling is how to get the Fortran kind to mlir float mapping.