### PR TITLE
fix type passed to InsertValueOp and ExtractValueOp builder

### DIFF
--- a/lib/burnside/convert-expr.cc
+++ b/lib/burnside/convert-expr.cc
@@ -243,11 +243,8 @@ class ExprLowering {
     auto *ctxt = builder.getContext();
     auto realTy{getFIRType(ctxt, defaults, RealCat, KIND)};
     auto index = genIntegerConstant<4>(ctxt, part.isImaginaryPart ? 1 : 0);
-    L::SmallVector<M::Type, 1> input({fir::CplxType::get(ctxt, KIND)});
-    L::SmallVector<M::Type, 1> output({realTy});
-    auto funcTy = M::FunctionType::get(input, output, ctxt);
     return builder.create<fir::ExtractValueOp>(
-        getLoc(), funcTy, genval(part.left()), index);
+        getLoc(), realTy, genval(part.left()), index);
   }
   template<Co::TypeCategory TC, int KIND>
   M::Value *genval(Ev::Negate<Ev::Type<TC, KIND>> const &) {
@@ -317,17 +314,14 @@ class ExprLowering {
     auto *ctxt = builder.getContext();
     auto complexTy{fir::CplxType::get(ctxt, KIND)};
     auto loc{getLoc()};
-    L::SmallVector<M::Type, 1> input(
-        {getFIRType(ctxt, defaults, RealCat, KIND)});
-    L::SmallVector<M::Type, 1> output({complexTy});
-    auto fTy = M::FunctionType::get(input, output, builder.getContext());
     auto und = builder.create<fir::UndefOp>(loc, complexTy);
     auto *lf = genval(op.left());
     auto *realIdx = genIntegerConstant<4>(ctxt, 0);
-    auto rp = builder.create<fir::InsertValueOp>(loc, fTy, und, lf, realIdx);
+    auto rp =
+        builder.create<fir::InsertValueOp>(loc, complexTy, und, lf, realIdx);
     auto *rt = genval(op.right());
     auto *imagIdx = genIntegerConstant<4>(ctxt, 1);
-    return builder.create<fir::InsertValueOp>(loc, fTy, rp, rt, imagIdx);
+    return builder.create<fir::InsertValueOp>(loc, complexTy, rp, rt, imagIdx);
   }
   template<int KIND> M::Value *genval(Ev::Concat<KIND> const &op) {
     // TODO this is a bogus call


### PR DESCRIPTION
The type passed to `InsertValueOp` and `ExtractValueOp` builder while lowering complex ops to FIR was not the one expected. I think the result type is the only thing needed. Currently, it was passed the operation type and mlir then seemed to take that for the result type which then created weird situation.

Example: Fortran complex constructor `z = (1., -1.)`
FIR dump before:
`%1 = fir.insert_value %0, %c0_i64 : (!fir.complex<8>, f64, i64) -> ((f64) -> !fir.complex<8>)`
FIR dump after:
`%4 = fir.insert_value %0, %c0_i64 : (!fir.complex<8>, f64, i64) -> !fir.complex<8>`



