### PR TITLE
Funtion Result and Extraction of Maths Runtime for other runtime 

### DIFF
--- a/lib/burnside/CMakeLists.txt
+++ b/lib/burnside/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(FortranBurnside
   flattened.cc
   intrinsics.cc
   runtime.cc
+  io.cc
 )
 
 target_link_libraries(FortranBurnside

--- a/lib/burnside/bridge.cc
+++ b/lib/burnside/bridge.cc
@@ -21,6 +21,7 @@
 #include "fir/Type.h"
 #include "flattened.h"
 #include "intrinsics.h"
+#include "io.h"
 #include "runtime.h"
 #include "../parser/parse-tree-visitor.h"
 #include "../semantics/tools.h"
@@ -600,7 +601,19 @@ class FIRConverter {
   void genFIR(const Pa::NullifyStmt &stmt) { TODO(); }
   void genFIR(const Pa::OpenStmt &stmt) { TODO(); }
   void genFIR(const Pa::PointerAssignmentStmt &stmt) { TODO(); }
-  void genFIR(const Pa::PrintStmt &stmt) { TODO(); }
+  void genFIR(const Pa::PrintStmt &stmt) {
+    llvm::SmallVector<mlir::Value *, 4> args;
+    for (const Pa::OutputItem &item :
+        std::get<std::list<Pa::OutputItem>>(stmt.t)) {
+      if (const Pa::Expr * parserExpr{std::get_if<Pa::Expr>(&item.u)}) {
+        mlir::Location loc{toLocation(parserExpr->source)};
+        args.push_back(createFIRExpr(loc, Se::GetExpr(*parserExpr)));
+      } else {
+        assert(false);  // implied do TODO
+      }
+    }
+    genPrintStatement(build(), toLocation(lastKnownPos), args);
+  }
   void genFIR(const Pa::ReadStmt &stmt) { TODO(); }
   void genFIR(const Pa::RewindStmt &stmt) { TODO(); }
   void genFIR(const Pa::SyncAllStmt &stmt) { TODO(); }

--- a/lib/burnside/complex.h
+++ b/lib/burnside/complex.h
@@ -1,0 +1,109 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_BURNSIDE_COMPLEX_H_
+#define FORTRAN_BURNSIDE_COMPLEX_H_
+
+/// [Coding style](https://llvm.org/docs/CodingStandards.html)
+
+#include "fe-helper.h"
+#include "fir/FIROps.h"
+#include "fir/Type.h"
+
+namespace Fortran::burnside {
+/// Provide helpers to generate Complex manipulations in FIR.
+
+class ComplexHandler {
+public:
+  ComplexHandler(mlir::OpBuilder &b, mlir::Location l) : builder{b}, loc{l} {}
+  mlir::Type getComplexPartType(fir::KindTy complexKind) {
+    return convertReal(builder.getContext(), complexKind);
+  }
+
+  mlir::Type getComplexPartType(mlir::Type complexType) {
+    return getComplexPartType(complexType.cast<fir::CplxType>().getFKind());
+  }
+
+  mlir::Type getComplexPartType(mlir::Value *cplx) {
+    assert(cplx != nullptr);
+    return getComplexPartType(cplx->getType());
+  }
+
+  mlir::Value *createComplexPart(mlir::Value *cplx, bool isImaginaryPart) {
+    return builder.create<fir::ExtractValueOp>(
+        loc, getComplexPartType(cplx), cplx, getPartId(isImaginaryPart));
+  }
+
+  mlir::Value *createComplexRealPart(mlir::Value *cplx) {
+    return createComplexPart(cplx, false);
+  }
+
+  mlir::Value *createComplexImagPart(mlir::Value *cplx) {
+    return createComplexPart(cplx, true);
+  }
+
+  mlir::Value *setComplexPart(
+      mlir::Value *cplx, mlir::Value *part, bool isImaginaryPart) {
+    assert(cplx != nullptr);
+    return builder.create<fir::InsertValueOp>(
+        loc, cplx->getType(), cplx, part, getPartId(isImaginaryPart));
+  }
+  mlir::Value *setRealPart(mlir::Value *cplx, mlir::Value *part) {
+    return setComplexPart(cplx, part, false);
+  }
+  mlir::Value *setImagPart(mlir::Value *cplx, mlir::Value *part) {
+    return setComplexPart(cplx, part, true);
+  }
+
+  mlir::Value *createComplex(
+      fir::KindTy kind, mlir::Value *real, mlir::Value *imag) {
+    mlir::Type complexTy{fir::CplxType::get(builder.getContext(), kind)};
+    mlir::Value *und{builder.create<fir::UndefOp>(loc, complexTy)};
+    return setImagPart(setRealPart(und, real), imag);
+  }
+
+  mlir::Value *createComplexCompare(
+      mlir::Value *cplx1, mlir::Value *cplx2, bool eq) {
+    mlir::Value *real1{createComplexRealPart(cplx1)};
+    mlir::Value *real2{createComplexRealPart(cplx2)};
+    mlir::Value *imag1{createComplexImagPart(cplx1)};
+    mlir::Value *imag2{createComplexImagPart(cplx2)};
+
+    mlir::CmpFPredicate predicate{
+        eq ? mlir::CmpFPredicate::UEQ : mlir::CmpFPredicate::UNE};
+    mlir::Value *realCmp{
+        builder.create<mlir::CmpFOp>(loc, predicate, real1, real2).getResult()};
+    mlir::Value *imagCmp{
+        builder.create<mlir::CmpFOp>(loc, predicate, imag1, imag2).getResult()};
+
+    if (eq) {
+      return builder.create<mlir::AndOp>(loc, realCmp, imagCmp).getResult();
+    } else {
+      return builder.create<mlir::OrOp>(loc, realCmp, imagCmp).getResult();
+    }
+  }
+
+private:
+  inline mlir::Value *getPartId(bool isImaginaryPart) {
+    auto type{mlir::IntegerType::get(32, builder.getContext())};
+    auto attr{builder.getIntegerAttr(type, isImaginaryPart ? 1 : 0)};
+    return builder.create<mlir::ConstantOp>(loc, type, attr).getResult();
+  }
+
+  mlir::OpBuilder &builder;
+  mlir::Location loc;
+};
+
+}
+#endif  // FORTRAN_BURNSIDE_COMPLEX_H_

--- a/lib/burnside/convert-expr.cc
+++ b/lib/burnside/convert-expr.cc
@@ -14,6 +14,7 @@
 
 #include "convert-expr.h"
 #include "builder.h"
+#include "complex.h"
 #include "fe-helper.h"
 #include "fir/Dialect.h"
 #include "fir/FIROps.h"
@@ -69,6 +70,7 @@ class ExprLowering {
   M::OpBuilder &builder;
   SomeExpr const &expr;
   SymMap &symMap;
+  SymMap loadedSymbols{};
   Co::IntrinsicTypeDefaultKinds const &defaults;
   IntrinsicLibrary const &intrinsics;
 
@@ -107,7 +109,7 @@ class ExprLowering {
   /// Generate an integral constant of `value`
   template<int KIND>
   M::Value *genIntegerConstant(M::MLIRContext *context, std::int64_t value) {
-    M::Type type{getFIRType(context, defaults, IntegerCat, 8)};
+    M::Type type{getFIRType(context, defaults, IntegerCat, KIND)};
     auto attr{builder.getIntegerAttr(type, value)};
     auto res{builder.create<M::ConstantOp>(getLoc(), type, attr)};
     return res.getResult();
@@ -226,7 +228,16 @@ class ExprLowering {
   }
   M::Value *gendef(Se::Symbol const *sym) { return gen(sym); }
   M::Value *genval(Se::Symbol const *sym) {
-    return builder.create<fir::LoadOp>(getLoc(), gen(sym));
+    // Do not load the same symbols several time in one expression.
+    // Fortran guarantees variable value must be the same wherever it
+    // appears in one expression.
+    if (mlir::Value * loaded{loadedSymbols.lookupSymbol(sym)}) {
+      return loaded;
+    } else {
+      mlir::Value *load{builder.create<fir::LoadOp>(getLoc(), gen(sym))};
+      loadedSymbols.addSymbol(sym, load);
+      return load;
+    }
   }
 
   M::Value *genval(Ev::BOZLiteralConstant const &) { TODO(); }
@@ -239,23 +250,23 @@ class ExprLowering {
   template<int KIND> M::Value *genval(Ev::TypeParamInquiry<KIND> const &) {
     TODO();
   }
+
   template<int KIND> M::Value *genval(Ev::ComplexComponent<KIND> const &part) {
-    auto *ctxt = builder.getContext();
-    auto realTy{getFIRType(ctxt, defaults, RealCat, KIND)};
-    auto index = genIntegerConstant<4>(ctxt, part.isImaginaryPart ? 1 : 0);
-    return builder.create<fir::ExtractValueOp>(
-        getLoc(), realTy, genval(part.left()), index);
+    return ComplexHandler{builder, getLoc()}.createComplexPart(
+        genval(part.left()), part.isImaginaryPart);
   }
+
   template<Co::TypeCategory TC, int KIND>
   M::Value *genval(Ev::Negate<Ev::Type<TC, KIND>> const &) {
     TODO();
   }
+
   template<Co::TypeCategory TC, int KIND>
   M::Value *genval(Ev::Add<Ev::Type<TC, KIND>> const &op) {
     if constexpr (TC == IntegerCat) {
       return createBinaryOp<M::AddIOp>(op);
     } else if constexpr (TC == RealCat) {
-      return createBinaryOp<M::AddFOp>(op);
+      return createBinaryOp<fir::AddfOp>(op);
     } else {
       static_assert(TC == ComplexCat, "Expected numeric type");
       return createBinaryOp<fir::AddcOp>(op);
@@ -266,7 +277,7 @@ class ExprLowering {
     if constexpr (TC == IntegerCat) {
       return createBinaryOp<M::SubIOp>(op);
     } else if constexpr (TC == RealCat) {
-      return createBinaryOp<M::SubFOp>(op);
+      return createBinaryOp<fir::SubfOp>(op);
     } else {
       static_assert(TC == ComplexCat, "Expected numeric type");
       return createBinaryOp<fir::SubcOp>(op);
@@ -277,7 +288,7 @@ class ExprLowering {
     if constexpr (TC == IntegerCat) {
       return createBinaryOp<M::MulIOp>(op);
     } else if constexpr (TC == RealCat) {
-      return createBinaryOp<M::MulFOp>(op);
+      return createBinaryOp<fir::MulfOp>(op);
     } else {
       static_assert(TC == ComplexCat, "Expected numeric type");
       return createBinaryOp<fir::MulcOp>(op);
@@ -288,7 +299,7 @@ class ExprLowering {
     if constexpr (TC == IntegerCat) {
       return createBinaryOp<M::DivISOp>(op);
     } else if constexpr (TC == RealCat) {
-      return createBinaryOp<M::DivFOp>(op);
+      return createBinaryOp<fir::DivfOp>(op);
     } else {
       static_assert(TC == ComplexCat, "Expected numeric type");
       return createBinaryOp<fir::DivcOp>(op);
@@ -310,18 +321,10 @@ class ExprLowering {
     M::Type ty{getFIRType(builder.getContext(), defaults, TC, KIND)};
     return intrinsics.genval(getLoc(), builder, "pow", ty, operands);
   }
+
   template<int KIND> M::Value *genval(Ev::ComplexConstructor<KIND> const &op) {
-    auto *ctxt = builder.getContext();
-    auto complexTy{fir::CplxType::get(ctxt, KIND)};
-    auto loc{getLoc()};
-    auto und = builder.create<fir::UndefOp>(loc, complexTy);
-    auto *lf = genval(op.left());
-    auto *realIdx = genIntegerConstant<4>(ctxt, 0);
-    auto rp =
-        builder.create<fir::InsertValueOp>(loc, complexTy, und, lf, realIdx);
-    auto *rt = genval(op.right());
-    auto *imagIdx = genIntegerConstant<4>(ctxt, 1);
-    return builder.create<fir::InsertValueOp>(loc, complexTy, rp, rt, imagIdx);
+    return ComplexHandler{builder, getLoc()}.createComplex(
+        KIND, genval(op.left()), genval(op.right()));
   }
   template<int KIND> M::Value *genval(Ev::Concat<KIND> const &op) {
     // TODO this is a bogus call
@@ -347,10 +350,20 @@ class ExprLowering {
       return createCompareOp<M::CmpIOp>(op, translateRelational(op.opr));
     } else if constexpr (TC == RealCat) {
       return createFltCmpOp<M::CmpFOp>(op, translateFloatRelational(op.opr));
+    } else if constexpr (TC == ComplexCat) {
+      bool eq{op.opr == Co::RelationalOperator::EQ};
+      assert(eq ||
+          op.opr == Co::RelationalOperator::NE &&
+              "relation undefined for complex");
+      return ComplexHandler{builder, getLoc()}.createComplexCompare(
+          genval(op.left()), genval(op.right()), eq);
     } else {
+      static_assert(TC == CharacterCat);
       TODO();
     }
   }
+
+  // TODO JP: the thing below should not be required.
   M::Value *genval(Ev::Relational<Ev::SomeType> const &op) {
     return std::visit([&](const auto &x) { return genval(x); }, op.u);
   }

--- a/lib/burnside/flattened.cc
+++ b/lib/burnside/flattened.cc
@@ -75,8 +75,8 @@ std::vector<LabelMention> GetAssign(
 }
 
 static std::tuple<const parser::Name *, LabelMention, LabelMention> FindStack(
-    const std::vector<std::tuple<const parser::Name *, LabelMention, LabelMention>>
-        &stack,
+    const std::vector<
+        std::tuple<const parser::Name *, LabelMention, LabelMention>> &stack,
     const parser::Name *key) {
   for (auto iter{stack.rbegin()}, iend{stack.rend()}; iter != iend; ++iter) {
     if (std::get<0>(*iter) == key) {
@@ -705,17 +705,10 @@ struct ControlFlowAnalyzer {
 
 }  // namespace flat
 
-template<typename A>
-void CreateFlatIR(const A &ptree, std::list<flat::Op> &ops, AnalysisData &ad) {
+void CreateFlatIR(std::list<flat::Op> &ops, AnalysisData &ad) {
   flat::ControlFlowAnalyzer linearize{ops, ad};
-  Walk(ptree, linearize);
+  std::visit(
+      [&](const auto *ptree) { Walk(*ptree, linearize); }, ad.parseTreeRoot);
 }
-
-#define INSTANTIATE_EXPLICITLY(T) \
-  template void CreateFlatIR<parser::T>( \
-      const parser::T &, std::list<flat::Op> &, AnalysisData &)
-INSTANTIATE_EXPLICITLY(MainProgram);
-INSTANTIATE_EXPLICITLY(FunctionSubprogram);
-INSTANTIATE_EXPLICITLY(SubroutineSubprogram);
 
 }  // namespace burnside

--- a/lib/burnside/flattened.h
+++ b/lib/burnside/flattened.h
@@ -214,24 +214,21 @@ std::vector<LabelMention> GetAssign(
 
 // Collection of data maintained internally by the flattening algorithm
 struct AnalysisData {
+  template<typename Node>
+  AnalysisData(const Node &node) : parseTreeRoot{&node} {}
+
   std::map<parser::Label, flat::LabelOp> labelMap;
   std::vector<
       std::tuple<const parser::Name *, flat::LabelMention, flat::LabelMention>>
       constructContextStack;
   flat::LabelBuilder labelBuilder;
   std::map<const semantics::Symbol *, std::set<parser::Label>> assignMap;
+  const std::variant<const parser::MainProgram *,
+      const parser::FunctionSubprogram *, const parser::SubroutineSubprogram *>
+      parseTreeRoot;
 };
 
-// entry-point into building the flat IR
-template<typename A>
-void CreateFlatIR(const A &ptree, std::list<flat::Op> &ops, AnalysisData &ad);
-
-#define EXPLICIT_INSTANTIATION(T) \
-  extern template void CreateFlatIR<parser::T>( \
-      const parser::T &, std::list<flat::Op> &, AnalysisData &)
-EXPLICIT_INSTANTIATION(MainProgram);
-EXPLICIT_INSTANTIATION(FunctionSubprogram);
-EXPLICIT_INSTANTIATION(SubroutineSubprogram);
+void CreateFlatIR(std::list<flat::Op> &, AnalysisData &);
 
 }  // namespace burnside
 

--- a/lib/burnside/io.cc
+++ b/lib/burnside/io.cc
@@ -1,0 +1,130 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "io.h"
+#include "builder.h"
+#include "runtime.h"
+#include "mlir/Dialect/StandardOps/Ops.h"
+#include "mlir/IR/Builders.h"
+
+namespace Fortran::burnside {
+
+/// Define actions to sort runtime functions. One actions
+/// may be associated to one or more runtime function.
+/// Actions are the keys in the StaticMultimapView used to
+/// hold the io runtime description in a static constexpr way.
+enum class IOAction { BeginExternalList, Output, EndIO };
+
+class IORuntimeDescription : public RuntimeStaticDescription {
+public:
+  using Key = IOAction;
+  constexpr IORuntimeDescription(
+      IOAction act, const char *s, MaybeTypeCode r, TypeCodeVector a)
+    : RuntimeStaticDescription{s, r, a}, key{act} {}
+  static mlir::Type getIOCookieType(mlir::MLIRContext *context) {
+    return getMLIRType(TypeCode::IOCookie, context);
+  }
+  IOAction key;
+};
+
+using IORuntimeMap = StaticMultimapView<IORuntimeDescription>;
+
+using RT = RuntimeStaticDescription;
+using RType = typename RT::TypeCode;
+using Args = typename RT::TypeCodeVector;
+using IOA = IOAction;
+
+/// This is were the IO runtime are to be described.
+/// The array need to be sorted on the Actions.
+/// Experimental runtime for now.
+static constexpr IORuntimeDescription ioRuntimeTable[]{
+    {IOA::BeginExternalList, "__F18IOa_BeginExternalListOutput",
+        RType::IOCookie, Args::create<RType::i32>()},
+    {IOA::Output, "__F18IOa_OutputInteger64", RT::voidTy,
+        Args::create<RType::IOCookie, RType::i64>()},
+    {IOA::Output, "__F18IOa_OutputReal64", RT::voidTy,
+        Args::create<RType::IOCookie, RType::f64>()},
+    {IOA::EndIO, "__F18IOa_EndIOStatement", RT::voidTy,
+        Args::create<RType::IOCookie>()},
+};
+
+static constexpr IORuntimeMap ioRuntimeMap{ioRuntimeTable};
+
+/// This helper can be used to access io runtime functions that
+/// are mapped to an IOAction that must be mapped to one and
+/// exactly one runtime function. This constraint is enforced
+/// at compile time. This search is resolved at compile time.
+template<IORuntimeDescription::Key key>
+static mlir::FuncOp getIORuntimeFunction(mlir::OpBuilder &builder) {
+  static constexpr auto runtimeDescription{ioRuntimeMap.find(key)};
+  static_assert(runtimeDescription != ioRuntimeMap.end());
+  return runtimeDescription->getFuncOp(builder);
+}
+
+/// This helper can be used to access io runtime functions that
+/// are mapped to Output IOAction that must be mapped to at least one
+/// runtime function but can be mapped to more functions.
+/// This helper returns the function that has the same
+/// mlir::FunctionType as the one seeked. It may therefore dynamically fail
+/// if no function mapped to the Action has the seeked mlir::FunctionType.
+static mlir::FuncOp getOutputRuntimeFunction(
+    mlir::OpBuilder &builder, mlir::Type type) {
+  static constexpr auto descriptionRange{ioRuntimeMap.getRange(IOA::Output)};
+  static_assert(!descriptionRange.empty());
+
+  mlir::MLIRContext *context{getModule(&builder).getContext()};
+  llvm::SmallVector<mlir::Type, 2> argTypes{
+      IORuntimeDescription::getIOCookieType(context), type};
+
+  mlir::FunctionType seekedType{mlir::FunctionType::get(argTypes, {}, context)};
+  for (const auto &description : descriptionRange) {
+    if (description.getMLIRFunctionType(context) == seekedType) {
+      return description.getFuncOp(builder);
+    }
+  }
+  assert(false && "IO output runtime function not defined for this type");
+  return {};
+}
+
+/// Lower print statement assuming a dummy runtime interface for now.
+void genPrintStatement(mlir::OpBuilder &builder, mlir::Location loc,
+    llvm::ArrayRef<mlir::Value *> args) {
+  mlir::ModuleOp module{getModule(&builder)};
+  mlir::MLIRContext *mlirContext{module.getContext()};
+
+  mlir::FuncOp beginFunc{
+      getIORuntimeFunction<IOAction::BeginExternalList>(builder)};
+
+  // Initiate io
+  mlir::Type externalUnitType{mlir::IntegerType::get(32, mlirContext)};
+  mlir::Value *defaultUnit{builder.create<mlir::ConstantOp>(
+      loc, builder.getIntegerAttr(externalUnitType, 1))};
+  llvm::SmallVector<mlir::Value *, 1> beginArgs{defaultUnit};
+  mlir::Value *cookie{
+      builder.create<mlir::CallOp>(loc, beginFunc, beginArgs).getResult(0)};
+
+  // Call data transfer runtime function
+  for (mlir::Value *arg : args) {
+    llvm::SmallVector<mlir::Value *, 1> operands{cookie, arg};
+    mlir::FuncOp outputFunc{getOutputRuntimeFunction(builder, arg->getType())};
+    builder.create<mlir::CallOp>(loc, outputFunc, operands);
+  }
+
+  // Terminate IO
+  mlir::FuncOp endIOFunc{getIORuntimeFunction<IOAction::EndIO>(builder)};
+  llvm::SmallVector<mlir::Value *, 1> endArgs{cookie};
+  builder.create<mlir::CallOp>(loc, endIOFunc, endArgs);
+}
+
+}

--- a/lib/burnside/io.h
+++ b/lib/burnside/io.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_BURNSIDE_IO_H_
+#define FORTRAN_BURNSIDE_IO_H_
+
+namespace mlir {
+class OpBuilder;
+class Location;
+class Value;
+}
+namespace llvm {
+template<typename T> class ArrayRef;
+}
+
+/// Experimental IO lowering to FIR + runtime. The Runtime design is under
+/// design.
+/// FIXME This interface is also not final. Should it be based on parser::..
+/// nodes and lower expressions as needed or should it get every expression
+/// already lowered as mlir::Value* ? (currently second options, not sure it
+/// will provide enough information for complex IO statements).
+namespace Fortran::burnside {
+void genPrintStatement(
+    mlir::OpBuilder &, mlir::Location loc, llvm::ArrayRef<mlir::Value *>);
+}
+
+#endif  // FORTRAN_BURNSIDE_IO_H_

--- a/lib/burnside/runtime.h
+++ b/lib/burnside/runtime.h
@@ -15,19 +15,147 @@
 #ifndef FORTRAN_BURNSIDE_RUNTIME_H_
 #define FORTRAN_BURNSIDE_RUNTIME_H_
 
-#include <string>
+#include <optional>
 
 namespace llvm {
 class StringRef;
 }
 namespace mlir {
+class Type;
 class FunctionType;
 class MLIRContext;
+class OpBuilder;
+class FuncOp;
 }
 
 namespace Fortran::burnside {
 
 /// [Coding style](https://llvm.org/docs/CodingStandards.html)
+
+/// Define a simple static runtime description that different runtime can
+/// derived from (e.g io, maths ...).
+/// This base class only define enough to generate the functuion declarations,
+// it is up to the actual runtime descriptions to define a way to organize these
+// descriptions in a meaningful way.
+/// It is constexpr constructible so that static tables of such descriptions can
+/// be safely stored as global variables without requiring global constructors.
+class RuntimeStaticDescription {
+public:
+  /// Define possible runtime function argument/return type used in signature
+  /// descriptions. They follow mlir standard types naming. MLIR types cannot
+  /// directly be used because they can only be dynamically built.
+  enum TypeCode { i32, i64, f32, f64, c32, c64, IOCookie };
+  using MaybeTypeCode = std::optional<TypeCode>;  // for results
+  static constexpr MaybeTypeCode voidTy{MaybeTypeCode{std::nullopt}};
+
+  /// C++ does not provide variable size constexpr container yet. TypeVector
+  /// implements one for Type elements. It works because Type is an enumeration.
+  struct TypeCodeVector {
+    template<TypeCode... v> struct Storage {
+      static constexpr TypeCode values[]{v...};
+    };
+    template<TypeCode... v> static constexpr TypeCodeVector create() {
+      const TypeCode *start{&Storage<v...>::values[0]};
+      return TypeCodeVector{start, start + sizeof...(v)};
+    }
+    template<> constexpr TypeCodeVector create<>() { return TypeCodeVector{}; }
+    const TypeCode *start{nullptr};
+    const TypeCode *end{nullptr};
+  };
+  constexpr RuntimeStaticDescription(
+      const char *s, MaybeTypeCode r, TypeCodeVector a)
+    : symbol{s}, resultTypeCode{r}, argumentTypeCodes{a} {}
+  const char *getSymbol() const { return symbol; }
+  /// Conversion between types of the static representation and MLIR types.
+  mlir::FunctionType getMLIRFunctionType(mlir::MLIRContext *) const;
+  mlir::FuncOp getFuncOp(mlir::OpBuilder &) const;
+  static mlir::Type getMLIRType(TypeCode, mlir::MLIRContext *);
+
+private:
+  const char *symbol{nullptr};
+  MaybeTypeCode resultTypeCode;
+  TypeCodeVector argumentTypeCodes;
+};
+
+/// StaticMultimapView is a constexpr friendly multimap
+/// implementation over sorted constexpr arrays.
+/// As the View name suggests, it does not duplicate the
+/// sorted array but only brings range and search concepts
+/// over it. It provides compile time search and can also
+/// provide dynamic search (currently linear, can be improved to
+/// log(n) due to the sorted array property).
+
+// TODO: Find a better place for this if this is retained.
+// This is currently here because this was designed to provide
+// maps over runtime description without the burden of having to
+// instantiate these maps dynamically and to keep they somewhere.
+template<typename Value> class StaticMultimapView {
+public:
+  using Key = typename Value::Key;
+  struct Range {
+    using const_iterator = const Value *;
+    constexpr const_iterator begin() const { return startPtr; }
+    constexpr const_iterator end() const { return endPtr; }
+    constexpr bool empty() const {
+      return startPtr == nullptr || endPtr == nullptr || endPtr <= startPtr;
+    }
+    constexpr std::size_t size() const {
+      return empty() ? 0 : static_cast<std::size_t>(endPtr - startPtr);
+    }
+    const Value *startPtr{nullptr};
+    const Value *endPtr{nullptr};
+  };
+  using const_iterator = typename Range::const_iterator;
+
+  template<std::size_t N>
+  constexpr StaticMultimapView(const Value (&array)[N])
+    : range{&array[0], &array[0] + N} {}
+  template<typename Key> constexpr bool verify() {
+    // TODO: sorted
+    // non empty increasing pointer direction
+    return !range.empty();
+  };
+  constexpr const_iterator begin() const { return range.begin(); }
+  constexpr const_iterator end() const { return range.end(); }
+
+  // Assume array is sorted.
+  // TODO make it a log(n) search based on sorted property
+  // std::equal_range will be constexpr in C++20 only.
+  constexpr Range getRange(const Key &key) const {
+    bool matched{false};
+    const Value *start{nullptr}, *end{nullptr};
+    for (const auto &desc : range) {
+      if (desc.key == key) {
+        if (!matched) {
+          start = &desc;
+          matched = true;
+        }
+      } else if (matched) {
+        end = &desc;
+        matched = false;
+      }
+    }
+    if (matched) {
+      end = range.end();
+    }
+    return Range{start, end};
+  }
+
+  constexpr std::pair<const_iterator, const_iterator> equal_range(
+      const Key &key) const {
+    Range range{getRange(key)};
+    return {range.begin(), range.end()};
+  }
+
+  constexpr typename Range::const_iterator find(Key key) const {
+    const Range subRange{getRange(key)};
+    return subRange.size() == 1 ? subRange.begin() : end();
+  }
+
+private:
+  Range range{nullptr, nullptr};
+};
+// TODO get rid of fake runtime below
 
 #define DEFINE_RUNTIME_ENTRY(A, B, C, D) FIRT_##A,
 enum RuntimeEntryCode {


### PR DESCRIPTION
This PR is a mix of several tasks I did last week. It is split in five commits with their own comments. Each commit is only dependent on the previous one this time (I tried to squash and rebase more cleverly).

Sumuary:

1. Move code generating FIR ops for Complex in their own class. This provide a more readable interface that can be use to manipulate complexes without repeating and depending on the boillerplate. 

2. Add root parse tree node to AnalysisData form flattening. This is to allow getting context information such as the function result symbol when generating FIR in the bridge. It also allows removing a few macros and narrowing the interface. Return Statement handling is improved in the bridge.

3. Lower user function call. Currently OK with implicit interface without need for temps.

4. Prevent reloading of the same symbols inside a same expression (optimizer may not be able to do so in case user function call are emitted in between). (*see example below)

5. Move `RuntimeStaticDescription` class from intrinsics.cc to runtime.h and remove the `name` field from it. Instead, create a `MathRuntimeDescription` class in intrinsics.cc that inherits from it and adds the math function name field. The idea behind is that the `RuntimeStaticDescription` can be used by any runtime description (io, coarrays...) for the common features (holding the symbol and signature as well as translation to mlir types). The way to organize these descriptions is left to each runtime. A StaticMultimapView class is added to `runtime.h` to help creating constexpr read-only multimap to help runtimes organizing their descriptions without requiring a dynamic structure that would have to be kept in context somewhere.

6. Implement an IO library framework based on the tools exposed before. The actual runtime does not quite matter so far. It can only handle `print *, x1, x2, ..., xn` where `xi` are scalar i64 or f64.

(*) Example Fortran program where the second load cannot be optimized out after Burnside:
```
function r_incr(x)
  real(8) :: r_incr, x
  r_incr = x
  x = x + 1.
end function
  real(8), external :: r_incr
  real(8) :: x, y
  x = 1._8
  y = x + r_incr(x) + x
  print *, y
end
```
I was able to observe this after your fix for loads.