### PR TITLE
Address comments from PR #8 and fix template bugs

### DIFF
--- a/lib/burnside/complex.h
+++ b/lib/burnside/complex.h
@@ -26,59 +26,59 @@ namespace Fortran::burnside {
 
 class ComplexHandler {
 public:
+  // The values of part enum members are meaningful for
+  // InsertValueOp and ExtractValueOp so they are explicit.
+  enum class Part { Real = 0, Imag = 1 };
+
   ComplexHandler(mlir::OpBuilder &b, mlir::Location l) : builder{b}, loc{l} {}
   mlir::Type getComplexPartType(fir::KindTy complexKind) {
     return convertReal(builder.getContext(), complexKind);
-  }
-
-  mlir::Type getComplexPartType(mlir::Type complexType) {
-    return getComplexPartType(complexType.cast<fir::CplxType>().getFKind());
-  }
-
-  mlir::Type getComplexPartType(mlir::Value *cplx) {
-    assert(cplx != nullptr);
-    return getComplexPartType(cplx->getType());
-  }
-
-  mlir::Value *createComplexPart(mlir::Value *cplx, bool isImaginaryPart) {
-    return builder.create<fir::ExtractValueOp>(
-        loc, getComplexPartType(cplx), cplx, getPartId(isImaginaryPart));
-  }
-
-  mlir::Value *createComplexRealPart(mlir::Value *cplx) {
-    return createComplexPart(cplx, false);
-  }
-
-  mlir::Value *createComplexImagPart(mlir::Value *cplx) {
-    return createComplexPart(cplx, true);
-  }
-
-  mlir::Value *setComplexPart(
-      mlir::Value *cplx, mlir::Value *part, bool isImaginaryPart) {
-    assert(cplx != nullptr);
-    return builder.create<fir::InsertValueOp>(
-        loc, cplx->getType(), cplx, part, getPartId(isImaginaryPart));
-  }
-  mlir::Value *setRealPart(mlir::Value *cplx, mlir::Value *part) {
-    return setComplexPart(cplx, part, false);
-  }
-  mlir::Value *setImagPart(mlir::Value *cplx, mlir::Value *part) {
-    return setComplexPart(cplx, part, true);
   }
 
   mlir::Value *createComplex(
       fir::KindTy kind, mlir::Value *real, mlir::Value *imag) {
     mlir::Type complexTy{fir::CplxType::get(builder.getContext(), kind)};
     mlir::Value *und{builder.create<fir::UndefOp>(loc, complexTy)};
-    return setImagPart(setRealPart(und, real), imag);
+    return insert<Part::Imag>(insert<Part::Real>(und, real), imag);
   }
 
+  // Complex part manipulation helpers
+  mlir::Type getComplexPartType(mlir::Type complexType) {
+    return getComplexPartType(complexType.cast<fir::CplxType>().getFKind());
+  }
+  mlir::Type getComplexPartType(mlir::Value *cplx) {
+    assert(cplx != nullptr);
+    return getComplexPartType(cplx->getType());
+  }
+
+  template<Part partId> mlir::Value *extract(mlir::Value *cplx) {
+    return builder.create<fir::ExtractValueOp>(
+        loc, getComplexPartType(cplx), cplx, getPartId<partId>());
+  }
+  template<Part partId>
+  mlir::Value *insert(mlir::Value *cplx, mlir::Value *part) {
+    assert(cplx != nullptr);
+    return builder.create<fir::InsertValueOp>(
+        loc, cplx->getType(), cplx, part, getPartId<partId>());
+  }
+
+  /// Complex part access helper dynamic versions
+  mlir::Value *extractComplexPart(mlir::Value *cplx, bool isImagPart) {
+    return isImagPart ? extract<Part::Imag>(cplx) : extract<Part::Real>(cplx);
+  }
+  mlir::Value *insertComplexPart(
+      mlir::Value *cplx, mlir::Value *part, bool isImagPart) {
+    return isImagPart ? insert<Part::Imag>(cplx, part)
+                      : insert<Part::Real>(cplx, part);
+  }
+
+  // Complex operation helpers
   mlir::Value *createComplexCompare(
       mlir::Value *cplx1, mlir::Value *cplx2, bool eq) {
-    mlir::Value *real1{createComplexRealPart(cplx1)};
-    mlir::Value *real2{createComplexRealPart(cplx2)};
-    mlir::Value *imag1{createComplexImagPart(cplx1)};
-    mlir::Value *imag2{createComplexImagPart(cplx2)};
+    mlir::Value *real1{extract<Part::Real>(cplx1)};
+    mlir::Value *real2{extract<Part::Real>(cplx2)};
+    mlir::Value *imag1{extract<Part::Imag>(cplx1)};
+    mlir::Value *imag2{extract<Part::Imag>(cplx2)};
 
     mlir::CmpFPredicate predicate{
         eq ? mlir::CmpFPredicate::UEQ : mlir::CmpFPredicate::UNE};
@@ -95,9 +95,10 @@ public:
   }
 
 private:
-  inline mlir::Value *getPartId(bool isImaginaryPart) {
+  // Make mlir ConstantOp from template part id.
+  template<Part partId> inline mlir::Value *getPartId() {
     auto type{mlir::IntegerType::get(32, builder.getContext())};
-    auto attr{builder.getIntegerAttr(type, isImaginaryPart ? 1 : 0)};
+    auto attr{builder.getIntegerAttr(type, static_cast<int>(partId))};
     return builder.create<mlir::ConstantOp>(loc, type, attr).getResult();
   }
 

--- a/lib/burnside/convert-expr.cc
+++ b/lib/burnside/convert-expr.cc
@@ -254,7 +254,7 @@ class ExprLowering {
   }
 
   template<int KIND> M::Value *genval(Ev::ComplexComponent<KIND> const &part) {
-    return ComplexHandler{builder, getLoc()}.createComplexPart(
+    return ComplexHandler{builder, getLoc()}.extractComplexPart(
         genval(part.left()), part.isImaginaryPart);
   }
 

--- a/lib/burnside/intrinsics.cc
+++ b/lib/burnside/intrinsics.cc
@@ -440,10 +440,10 @@ mlir::Value *IntrinsicLibrary::Implementation::generateConjg(
   mlir::Type realType{cplxHandler.getComplexPartType(cplx)};
   mlir::Value *zero{builder.create<mlir::ConstantOp>(
       genCtxt.loc, realType, builder.getZeroAttr(realType))};
-  mlir::Value *imag{cplxHandler.createComplexImagPart(cplx)};
+  mlir::Value *imag{cplxHandler.extract<ComplexHandler::Part::Imag>(cplx)};
   mlir::Value *negImag{
       genCtxt.builder->create<mlir::SubFOp>(genCtxt.loc, zero, imag)};
-  return cplxHandler.setImagPart(cplx, negImag);
+  return cplxHandler.insert<ComplexHandler::Part::Imag>(cplx, negImag);
 }
 
 }

--- a/lib/burnside/runtime.cc
+++ b/lib/burnside/runtime.cc
@@ -44,9 +44,8 @@ mlir::Type RuntimeStaticDescription::getMLIRType(
 mlir::FunctionType RuntimeStaticDescription::getMLIRFunctionType(
     mlir::MLIRContext *context) const {
   llvm::SmallVector<mlir::Type, 2> argMLIRTypes;
-  for (const TypeCode *t{argumentTypeCodes.start};
-       t != nullptr && t != argumentTypeCodes.end; ++t) {
-    argMLIRTypes.push_back(getMLIRType(*t, context));
+  for (const TypeCode &t : argumentTypeCodes) {
+    argMLIRTypes.push_back(getMLIRType(t, context));
   }
   if (resultTypeCode.has_value()) {
     mlir::Type resMLIRType{getMLIRType(*resultTypeCode, context)};

--- a/lib/burnside/runtime.h
+++ b/lib/burnside/runtime.h
@@ -58,8 +58,10 @@ public:
       const TypeCode *start{&Storage<v...>::values[0]};
       return TypeCodeVector{start, start + sizeof...(v)};
     }
-    // g++ 8.3 says: "error: explicit specialization in non-namespace scope ‘struct Fortran::burnside::RuntimeStaticDescription::TypeCodeVector’"
-    //template<> constexpr TypeCodeVector create<>() { return TypeCodeVector{}; }
+    // g++ 8.3 says: "error: explicit specialization in non-namespace scope
+    // ‘struct Fortran::burnside::RuntimeStaticDescription::TypeCodeVector’"
+    // template<> constexpr TypeCodeVector create<>() { return TypeCodeVector{};
+    // }
     const TypeCode *start{nullptr};
     const TypeCode *end{nullptr};
   };
@@ -89,7 +91,7 @@ private:
 // TODO: Find a better place for this if this is retained.
 // This is currently here because this was designed to provide
 // maps over runtime description without the burden of having to
-// instantiate these maps dynamically and to keep they somewhere.
+// instantiate these maps dynamically and to keep them somewhere.
 template<typename Value> class StaticMultimapView {
 public:
   using Key = typename Value::Key;

--- a/lib/burnside/runtime.h
+++ b/lib/burnside/runtime.h
@@ -32,6 +32,49 @@ namespace Fortran::burnside {
 
 /// [Coding style](https://llvm.org/docs/CodingStandards.html)
 
+/// C++ does not provide variable size constexpr container yet.
+/// StaticVector is a class that can be used to hold constexpr data as if it was
+/// a vector (i.e, the number of element is not reflected in the
+/// container type). This is useful to use in classes that need to be constexpr
+/// and where leaking the size as a template type would make it harder to
+/// manipulate. It can hold whatever data that can appear as non-type templates
+/// (integers, enums, pointer to objects, function pointers...).
+/// Example usage:
+///
+///  enum class Enum {A, B};
+///  constexpr StaticVector<Enum> vec{StaticVector::create<Enum::A, Enum::B>()};
+///  for (const Enum& code : vec) { /*...*/ }
+///
+
+/// This is the class where the constexpr data is "allocated". In fact
+/// the data is stored "in" the type. Objects of this type are not meant to
+/// be ever constructed.
+template<typename T, T... v> struct StaticVectorStorage {
+  static constexpr T values[]{v...};
+  static constexpr const T *start{&values[0]};
+  static constexpr const T *end{start + sizeof...(v)};
+};
+template<typename T> struct StaticVectorStorage<T> {
+  static constexpr const T *start{nullptr}, *end{nullptr};
+};
+
+/// StaticVector cannot be directly constructed, instead its
+/// `create` static method has to be used to create StaticVector objects.
+/// StaticVector are views over the StaticVectorStorage type that was built
+/// while instantiating the create method. They do not duplicate the values from
+/// these read-only storages.
+template<typename T> struct StaticVector {
+  template<T... v> static constexpr StaticVector create() {
+    using storage = StaticVectorStorage<T, v...>;
+    return StaticVector{storage::start, storage::end};
+  }
+  using const_iterator = const T *;
+  constexpr const_iterator begin() const { return startPtr; }
+  constexpr const_iterator end() const { return endPtr; }
+  const T *startPtr{nullptr};
+  const T *endPtr{nullptr};
+};
+
 /// Define a simple static runtime description that different runtime can
 /// derived from (e.g io, maths ...).
 /// This base class only define enough to generate the functuion declarations,
@@ -39,6 +82,7 @@ namespace Fortran::burnside {
 /// these descriptions in a meaningful way.
 /// It is constexpr constructible so that static tables of such descriptions can
 /// be safely stored as global variables without requiring global constructors.
+
 class RuntimeStaticDescription {
 public:
   /// Define possible runtime function argument/return type used in signature
@@ -46,25 +90,9 @@ public:
   /// directly be used because they can only be dynamically built.
   enum TypeCode { i32, i64, f32, f64, c32, c64, IOCookie };
   using MaybeTypeCode = std::optional<TypeCode>;  // for results
+  using TypeCodeVector = StaticVector<TypeCode>;  // for arguments
   static constexpr MaybeTypeCode voidTy{MaybeTypeCode{std::nullopt}};
 
-  /// C++ does not provide variable size constexpr container yet. TypeVector
-  /// implements one for Type elements. It works because Type is an enumeration.
-  struct TypeCodeVector {
-    template<TypeCode... v> struct Storage {
-      static constexpr TypeCode values[]{v...};
-    };
-    template<TypeCode... v> static constexpr TypeCodeVector create() {
-      const TypeCode *start{&Storage<v...>::values[0]};
-      return TypeCodeVector{start, start + sizeof...(v)};
-    }
-    // g++ 8.3 says: "error: explicit specialization in non-namespace scope
-    // ‘struct Fortran::burnside::RuntimeStaticDescription::TypeCodeVector’"
-    // template<> constexpr TypeCodeVector create<>() { return TypeCodeVector{};
-    // }
-    const TypeCode *start{nullptr};
-    const TypeCode *end{nullptr};
-  };
   constexpr RuntimeStaticDescription(
       const char *s, MaybeTypeCode r, TypeCodeVector a)
     : symbol{s}, resultTypeCode{r}, argumentTypeCodes{a} {}


### PR DESCRIPTION
Address  PR #8 comments.

- Use template instead of bool inside complex to encode part
- Use Twine
- Other Editorial changes

Fix template bug with the empty `TypeCodeVector` (we may have runtime functions with no args, so this needs to work). I moved the "constexpr vector" aspect in its own class. In a way, it is also nicer because other things can now use it (it should probably go in `lib/common/constexpr-containers.h` with the constexpr multimap at some point).