### PR TITLE
Fix symbol fallout

### DIFF
--- a/lib/burnside/builder.cc
+++ b/lib/burnside/builder.cc
@@ -45,11 +45,11 @@ mlir::FuncOp B::getNamedFunction(mlir::ModuleOp module, llvm::StringRef name) {
   return module.lookupSymbol<mlir::FuncOp>(name);
 }
 
-void B::SymMap::addSymbol(const semantics::Symbol *symbol, mlir::Value *value) {
-  symbolMap.try_emplace(symbol, value);
+void B::SymMap::addSymbol(semantics::SymbolRef symbol, mlir::Value *value) {
+  symbolMap.try_emplace(&*symbol, value);
 }
 
-mlir::Value *B::SymMap::lookupSymbol(const semantics::Symbol *symbol) {
-  auto iter{symbolMap.find(symbol)};
+mlir::Value *B::SymMap::lookupSymbol(semantics::SymbolRef symbol) {
+  auto iter{symbolMap.find(&*symbol)};
   return (iter == symbolMap.end()) ? nullptr : iter->second;
 }

--- a/lib/burnside/builder.h
+++ b/lib/burnside/builder.h
@@ -40,9 +40,9 @@ class SymMap {
   llvm::DenseMap<const semantics::Symbol *, mlir::Value *> symbolMap;
 
 public:
-  void addSymbol(const semantics::Symbol *symbol, mlir::Value *value);
+  void addSymbol(semantics::SymbolRef symbol, mlir::Value *value);
 
-  mlir::Value *lookupSymbol(const semantics::Symbol *symbol);
+  mlir::Value *lookupSymbol(semantics::SymbolRef symbol);
 };
 
 std::string applyNameMangling(llvm::StringRef parserName);

--- a/lib/burnside/convert-expr.cc
+++ b/lib/burnside/convert-expr.cc
@@ -226,18 +226,18 @@ class ExprLowering {
   M::Value *gen(Se::SymbolRef sym) {
     // FIXME: not all symbols are local
     return createTemporary(getLoc(), builder, symMap,
-        translateSymbolToFIRType(builder.getContext(), defaults, &*sym), &*sym);
+        translateSymbolToFIRType(builder.getContext(), defaults, sym), &*sym);
   }
   M::Value *gendef(Se::SymbolRef sym) { return gen(sym); }
   M::Value *genval(Se::SymbolRef sym) {
     // Do not load the same symbols several time in one expression.
     // Fortran guarantees variable value must be the same wherever it
     // appears in one expression.
-    if (mlir::Value * loaded{loadedSymbols.lookupSymbol(&*sym)}) {
+    if (mlir::Value * loaded{loadedSymbols.lookupSymbol(sym)}) {
       return loaded;
     } else {
       mlir::Value *load{builder.create<fir::LoadOp>(getLoc(), gen(sym))};
-      loadedSymbols.addSymbol(&*sym, load);
+      loadedSymbols.addSymbol(sym, load);
       return load;
     }
   }
@@ -521,7 +521,7 @@ class ExprLowering {
       coorArgs.push_back(builder.create<fir::FieldIndexOp>(getLoc(), name));
     }
     assert(sym && "no component(s)?");
-    M::Type ty{translateSymbolToFIRType(builder.getContext(), defaults, sym)};
+    M::Type ty{translateSymbolToFIRType(builder.getContext(), defaults, *sym)};
     ty = fir::ReferenceType::get(ty);
     return builder.create<fir::CoordinateOp>(getLoc(), ty, obj, coorArgs);
   }
@@ -565,7 +565,6 @@ class ExprLowering {
   M::Value *gen(Ev::ArrayRef const &aref) {
     M::Value *base;
     if (aref.base().IsSymbol())
-      // base = gen(const_cast<Se::Symbol *>(&aref.base().GetFirstSymbol()));
       base = gen(aref.base().GetFirstSymbol());
     else
       base = gen(aref.base().GetComponent());
@@ -641,7 +640,7 @@ class ExprLowering {
         const auto *expr{arg->UnwrapExpr()};
         assert(expr && "assumed type argument requires explicit interface");
         if (const Se::Symbol * sym{Ev::UnwrapWholeSymbolDataRef(*expr)}) {
-          M::Value *argRef{symMap.lookupSymbol(sym)};
+          M::Value *argRef{symMap.lookupSymbol(*sym)};
           assert(argRef && "could not get symbol reference");
           argTypes.push_back(argRef->getType());
           operands.push_back(argRef);
@@ -710,7 +709,7 @@ M::Value *Br::createSomeAddress(M::Location loc, M::OpBuilder &builder,
 M::Value *Br::createTemporary(M::Location loc, M::OpBuilder &builder,
     SymMap &symMap, M::Type type, Se::Symbol const *symbol) {
   if (symbol)
-    if (auto *val{symMap.lookupSymbol(symbol)}) {
+    if (auto *val{symMap.lookupSymbol(*symbol)}) {
       if (auto *op{val->getDefiningOp()}) {
         return op->getResult(0);
       }
@@ -722,7 +721,7 @@ M::Value *Br::createTemporary(M::Location loc, M::OpBuilder &builder,
   assert(!type.dyn_cast<fir::ReferenceType>() && "cannot be a reference");
   if (symbol) {
     ae = builder.create<fir::AllocaOp>(loc, type, symbol->name().ToString());
-    symMap.addSymbol(symbol, ae);
+    symMap.addSymbol(*symbol, ae);
   } else {
     ae = builder.create<fir::AllocaOp>(loc, type);
   }

--- a/lib/burnside/fe-helper.cc
+++ b/lib/burnside/fe-helper.cc
@@ -220,7 +220,7 @@ public:
 
   M::Type mkVoid() { return M::TupleType::get(context); }
 
-  fir::SequenceType::Shape genSeqShape(const Se::Symbol *symbol) {
+  fir::SequenceType::Shape genSeqShape(Se::SymbolRef symbol) {
     assert(symbol->IsObjectArray());
     fir::SequenceType::Bounds bounds;
     auto &details = symbol->get<Se::ObjectEntityDetails>();
@@ -250,8 +250,7 @@ public:
 
   /// Type consing from a symbol. A symbol's type must be created from the type
   /// discovered by the front-end at runtime.
-  M::Type gen(Se::SymbolRef symref) {
-    const Se::Symbol *symbol{&*symref};  // TODO JP: clean this
+  M::Type gen(Se::SymbolRef symbol) {
     if (auto *proc = symbol->detailsIf<Se::SubprogramDetails>()) {
       M::Type returnTy{mkVoid()};
       if (proc->isFunction()) {
@@ -381,9 +380,8 @@ M::Type Br::translateSomeExprToFIRType(M::MLIRContext *context,
 // This entry point avoids gratuitously wrapping the Symbol instance in layers
 // of Expr<T> that will then be immediately peeled back off and discarded.
 M::Type Br::translateSymbolToFIRType(M::MLIRContext *context,
-    Co::IntrinsicTypeDefaultKinds const &defaults, const Se::Symbol *symbol) {
-  assert(symbol);  // TODO JP: move to SymbolRef ?
-  return TypeBuilder{context, defaults}.gen(*symbol);
+    Co::IntrinsicTypeDefaultKinds const &defaults, Se::SymbolRef symbol) {
+  return TypeBuilder{context, defaults}.gen(symbol);
 }
 
 M::Type Br::convertReal(M::MLIRContext *context, int kind) {

--- a/lib/burnside/fe-helper.h
+++ b/lib/burnside/fe-helper.h
@@ -32,6 +32,7 @@ class Type;
 namespace Fortran {
 namespace common {
 class IntrinsicTypeDefaultKinds;
+template<typename T> class Reference;
 }  // common
 
 namespace evaluate {
@@ -50,6 +51,7 @@ class CookedSource;
 
 namespace semantics {
 class Symbol;
+using SymbolRef = common::Reference<const Symbol>;
 }  // semantics
 
 namespace burnside {
@@ -100,7 +102,7 @@ mlir::Type translateSomeExprToFIRType(mlir::MLIRContext *ctxt,
 
 mlir::Type translateSymbolToFIRType(mlir::MLIRContext *ctxt,
     common::IntrinsicTypeDefaultKinds const &defaults,
-    const semantics::Symbol *symbol);
+    const semantics::SymbolRef symbol);
 
 mlir::Type convertReal(mlir::MLIRContext *context, int KIND);
 


### PR DESCRIPTION
https://github.com/flang-compiler/f18/pull/788 changed many `const Symbol*` elements to `common::Reference<const Symbol>`  a.k.a. `SymbolRef` to indicate these pointers cannot be null.
This broke the bridge.
This PR both fixes the issue at the interface and also propagate the usage of `SymbolRef` inside the bridge to differentiate places where `Symbol*` can be nullptr or not.