### PR TITLE
Update FIR build intsructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is quite similar to the old way, but with a few subtle differences.
 4. Create a build space for cmake and make/ninja
 
 ```
-  mkdir build; cd build; cmake ../f18-llvm-project/llvm -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_PROJECTS=flang -DCMAKE_CXX_STANDARD=17 <other-arguments>
+  mkdir build; cd build; cmake ../f18-llvm-project/llvm -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_EXTERNAL_PROJECTS=flang -DLLVM_ENABLE_PROJECTS=flang -DCMAKE_CXX_STANDARD=17 <other-arguments>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
 -->
 
 # FIR
@@ -13,30 +13,30 @@ This is quite similar to the old way, but with a few subtle differences.
 1. Get the stuff.
 
 ```
-  git clone git@github.com:llvm/llvm-project.git
-  git clone git@github.com:schweitzpgi/mlir.git
+  git clone git@github.com:flang-compiler/f18-llvm-project.git
+  git clone git@github.com:flang-compiler/f18-mlir.git
   git clone git@github.com:schweitzpgi/f18.git 
 ```
 
 2. Get "on" the right branches.
 
 ```
-  (cd llvm-project; git checkout master)
-  (cd mlir; git checkout f18)
+  (cd f18-llvm-project; git checkout master)
+  (cd f18-mlir; git checkout f18)
   (cd f18; git checkout f18)
 ```
              
 3. Setup the LLVM space for in-tree builds.
    
 ``` 
-  cd llvm-project/llvm/projects ; ln -s ../../../mlir .
-  cd llvm-project ; ln -s ../f18 flang
+  cd f18-llvm-project/llvm/projects ; ln -s ../../../f18-mlir mlir
+  cd f18-llvm-project ; ln -s ../f18 flang
 ```
 
 4. Create a build space for cmake and make/ninja
 
 ```
-  mkdir build; cd build; cmake ../llvm-project/llvm -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_PROJECTS=flang -DCMAKE_CXX_STANDARD=17 <other-arguments>
+  mkdir build; cd build; cmake ../f18-llvm-project/llvm -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_PROJECTS=flang -DCMAKE_CXX_STANDARD=17 <other-arguments>
 ```
 
 

--- a/include/fir/FIROps.td
+++ b/include/fir/FIROps.td
@@ -87,10 +87,17 @@ def fir_DimsType : Type<CPred<"$_self.isa<fir::DimsType>()">, "dim type">;
 def fir_TypeDescType : Type<CPred<"$_self.isa<fir::TypeDescType>()">,
     "type desc type">;
 def fir_FieldType : Type<CPred<"$_self.isa<fir::FieldType>()">, "field type">;
+def fir_LenType : Type<CPred<"$_self.isa<fir::LenType>()">,
+    "LEN parameter type">;
 
-def AnyCoordinateLike : TypeConstraint<Or<[AnyInteger.predicate,
+def AnyComponentLike : TypeConstraint<Or<[AnyInteger.predicate,
     Index.predicate, fir_IntegerType.predicate, fir_FieldType.predicate]>,
     "any coordinate index">;
+def AnyComponentType : Type<AnyComponentLike.predicate, "coordinate type">;
+
+def AnyCoordinateLike : TypeConstraint<Or<[AnyInteger.predicate,
+    Index.predicate, fir_IntegerType.predicate, fir_FieldType.predicate,
+    fir_LenType.predicate]>, "any coordinate index">;
 def AnyCoordinateType : Type<AnyCoordinateLike.predicate, "coordinate type">;
 
 class fir_Op<string mnemonic, list<OpTrait> traits>
@@ -1141,7 +1148,7 @@ def fir_CoordinateOp : fir_Op<"coordinate_of", [NoSideEffect]>,
 }
 
 def fir_ExtractValueOp : fir_OneResultOp<"extract_value", [NoSideEffect]>,
-    Arguments<(ins AnyCompositeLike:$adt, Variadic<AnyCoordinateType>:$coor)> {
+    Arguments<(ins AnyCompositeLike:$adt, Variadic<AnyComponentType>:$coor)> {
   let summary = "Extract a value from an aggregate SSA-value";
 
   let description = [{
@@ -1256,7 +1263,7 @@ def fir_GenDimsOp : fir_OneResultOp<"gendims", [NoSideEffect]>,
 
 def fir_InsertValueOp : fir_OneResultOp<"insert_value", [NoSideEffect]>,
     Arguments<(ins AnyCompositeLike:$adt, AnyType:$val,
-    Variadic<AnyCoordinateType>:$coor)> {
+    Variadic<AnyComponentType>:$coor)> {
   let summary = "insert a new sub-value into a copy of an existing aggregate";
 
   let description = [{
@@ -1291,12 +1298,10 @@ def fir_LenParamIndexOp : fir_OneResultOp<"len_param_index", [NoSideEffect]> {
     "create a field index value from a LEN type parameter identifier";
 
   let description = [{
-    Generate a field (offset) value from an LEN parameter identifier.  Field
-    values may be lowered into exact offsets when the layout of a Fortran
-    derived type is known at compile-time. The type of a field value is
-    `!fir.field` and these values can be used with the `fir.coordinate_of`,
-    `fir.extract_value`, or `fir.insert_value` instructions to compute
-    (abstract) addresses of subobjects.
+    Generate a LEN parameter (offset) value from an LEN parameter identifier.
+    The type of a LEN parameter value is `!fir.len` and these values can be
+    used with the `fir.coordinate_of` instructions to compute (abstract)
+    addresses of LEN parameters.
   }];
 
   let arguments = (ins StrAttr:$field_id);
@@ -1320,17 +1325,21 @@ def fir_LenParamIndexOp : fir_OneResultOp<"len_param_index", [NoSideEffect]> {
       result.addAttribute("field_id",
           parser.getBuilder().getStringAttr(fieldName));
     }
-    M::Type type;
-    if (parser.parseRParen() ||
-        parser.parseColonType(type) ||
-        parser.addTypeToList(type, result.types))
+    if (parser.parseRParen())
       return M::failure();
+    auto lenType = fir::LenType::get(parser.getBuilder().getContext());
+    result.addAttribute("out_type", M::TypeAttr::get(lenType));
     return M::success();
   }];
 
   let printer = [{
-    p << getOperationName() << " (" << getAttr("field_id") << ") : "
-      << getType();
+    p << getOperationName() << " (" << getAttr("field_id") << ')';
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::Type getType() {
+      return getAttrOfType<mlir::TypeAttr>("out_type").getValue();
+    }
   }];
 }
 

--- a/include/fir/FIROps.td
+++ b/include/fir/FIROps.td
@@ -1345,7 +1345,7 @@ def fir_LoopOp : fir_Op<"loop", [ImplicitFirTerminator]> {
   }];
   let arguments = (ins Index:$lowerBound, Index:$upperBound,
                    Variadic<Index>:$optstep, OptionalAttr<I32Attr>:$constep,
-                   OptionalAttr<BoolAttr>:$unordered);
+                   OptionalAttr<UnitAttr>:$unordered);
   let regions = (region SizedRegion<1>:$region);
   let skipDefaultBuilders = 1;
   let builders = [

--- a/include/fir/Type.h
+++ b/include/fir/Type.h
@@ -43,6 +43,7 @@ struct DimsTypeStorage;
 struct FieldTypeStorage;
 struct HeapTypeStorage;
 struct IntTypeStorage;
+struct LenTypeStorage;
 struct LogicalTypeStorage;
 struct PointerTypeStorage;
 struct RealTypeStorage;
@@ -65,6 +66,7 @@ enum TypeKind {
   FIR_FIELD,
   FIR_HEAP,
   FIR_INT,     // intrinsic
+  FIR_LEN,
   FIR_LOGICAL, // intrinsic
   FIR_POINTER,
   FIR_REAL, // intrinsic
@@ -200,6 +202,14 @@ public:
   static mlir::LogicalResult
   verifyConstructionInvariants(llvm::Optional<mlir::Location> loc,
                                mlir::MLIRContext *context, mlir::Type eleTy);
+};
+
+class LenType
+    : public mlir::Type::TypeBase<LenType, mlir::Type, detail::LenTypeStorage> {
+public:
+  using Base::Base;
+  static LenType get(mlir::MLIRContext *ctxt, KindTy _ = 0);
+  static bool kindof(unsigned kind) { return kind == TypeKind::FIR_LEN; }
 };
 
 class PointerType : public mlir::Type::TypeBase<PointerType, mlir::Type,

--- a/lib/fir/FIROps.cpp
+++ b/lib/fir/FIROps.cpp
@@ -249,9 +249,8 @@ void DispatchTableOp::build(M::Builder *builder, M::OperationState *result,
                             L::StringRef name, M::Type type,
                             L::ArrayRef<M::NamedAttribute> attrs) {
   result->addAttribute("method", builder->getStringAttr(name));
-  for (const auto &pair : attrs) {
+  for (const auto &pair : attrs)
     result->addAttribute(pair.first, pair.second);
-  }
 }
 
 M::ParseResult DispatchTableOp::parse(M::OpAsmParser &parser,
@@ -305,9 +304,8 @@ void GlobalOp::build(M::Builder *builder, M::OperationState *result,
   result->addAttribute(getTypeAttrName(), M::TypeAttr::get(type));
   result->addAttribute(M::SymbolTable::getSymbolAttrName(),
                        builder->getStringAttr(name));
-  for (const auto &pair : attrs) {
+  for (const auto &pair : attrs)
     result->addAttribute(pair.first, pair.second);
-  }
 }
 
 M::ParseResult GlobalOp::parse(M::OpAsmParser &parser,
@@ -321,17 +319,15 @@ M::ParseResult GlobalOp::parse(M::OpAsmParser &parser,
   auto &builder = parser.getBuilder();
   result.attributes.back().second = builder.getStringAttr(nameAttr.getValue());
 
-  if (parser.parseOptionalKeyword("constant")) {
-    result.addAttribute("constant", builder.getBoolAttr(false));
-  } else {
+  if (!parser.parseOptionalKeyword("constant")) {
     // if "constant" keyword then mark this as a constant, not a variable
-    result.addAttribute("constant", builder.getBoolAttr(true));
+    result.addAttribute("constant", builder.getUnitAttr());
   }
 
   M::Type globalType;
-  if (parser.parseColonType(globalType)) {
+  if (parser.parseColonType(globalType))
     return M::failure();
-  }
+
   result.addAttribute(getTypeAttrName(), M::TypeAttr::get(globalType));
 
   // Parse the optional initializer body.
@@ -349,7 +345,7 @@ void GlobalOp::print(M::OpAsmPrinter &p) {
   auto varName =
       getAttrOfType<StringAttr>(M::SymbolTable::getSymbolAttrName()).getValue();
   p << getOperationName() << " @" << varName;
-  if (getAttr("constant").cast<M::BoolAttr>().getValue())
+  if (getAttr("constant"))
     p << " constant";
   p << " : ";
   p.printType(getType());
@@ -415,6 +411,7 @@ M::ParseResult parseLoopOp(M::OpAsmParser &parser, M::OperationState &result) {
       parser.parseKeyword("to") || parser.parseOperand(ub) ||
       parser.resolveOperand(ub, indexType, result.operands))
     return M::failure();
+
   if (parser.parseOptionalKeyword(LoopOp::getStepKeyword())) {
     result.addAttribute(LoopOp::getStepKeyword(),
                         builder.getIntegerAttr(builder.getIndexType(), 1));
@@ -423,11 +420,8 @@ M::ParseResult parseLoopOp(M::OpAsmParser &parser, M::OperationState &result) {
     return M::failure();
   }
 
-  if (parser.parseOptionalKeyword("unordered")) {
-    // ok
-  } else {
-    result.addAttribute("unordered", builder.getBoolAttr(true));
-  }
+  if (!parser.parseOptionalKeyword("unordered"))
+    result.addAttribute("unordered", builder.getUnitAttr());
 
   // Parse the body region.
   M::Region *body = result.addRegion();
@@ -490,23 +484,21 @@ M::ParseResult parseWhereOp(M::OpAsmParser &parser, M::OperationState &result) {
       parser.resolveOperand(cond, i1Type, result.operands))
     return M::failure();
 
-  if (parser.parseRegion(*thenRegion, {}, {})) {
+  if (parser.parseRegion(*thenRegion, {}, {}))
     return M::failure();
-  }
+
   WhereOp::ensureTerminator(*thenRegion, parser.getBuilder(), result.location);
 
   if (!parser.parseOptionalKeyword("otherwise")) {
-    if (parser.parseRegion(*elseRegion, {}, {})) {
+    if (parser.parseRegion(*elseRegion, {}, {}))
       return M::failure();
-    }
     WhereOp::ensureTerminator(*elseRegion, parser.getBuilder(),
                               result.location);
   }
 
   // Parse the optional attribute list.
-  if (parser.parseOptionalAttributeDict(result.attributes)) {
+  if (parser.parseOptionalAttributeDict(result.attributes))
     return M::failure();
-  }
 
   return M::success();
 }
@@ -527,9 +519,8 @@ unsigned getCaseArgumentOffset(L::ArrayRef<M::Attribute> cases, unsigned dest) {
     auto &attr = cases[i];
     if (!attr.dyn_cast_or_null<M::UnitAttr>()) {
       ++o;
-      if (attr.dyn_cast_or_null<ClosedIntervalAttr>()) {
+      if (attr.dyn_cast_or_null<ClosedIntervalAttr>())
         ++o;
-      }
     }
   }
   return o;

--- a/test/fir/aggregate.fir
+++ b/test/fir/aggregate.fir
@@ -1,0 +1,11 @@
+func @f_tuple(%a : tuple<i32, i64>) -> i64 {
+  %0 = constant 1 : i32
+  %1 = fir.extract_value %a, %0 : (tuple<i32, i64>, i32) -> i64
+  return %1 : i64
+}
+
+func @f_record(%a : !fir.type<rec1{fa:i32, fb:i64}>) -> i64 {
+  %0 = fir.field_index("fb") : !fir.field
+  %1 = fir.extract_value %a, %0 : (!fir.type<rec1{fa:i32, fb:i64}>, !fir.field) -> i64
+  return %1 : i64
+}

--- a/tools/bbc/bbc.cc
+++ b/tools/bbc/bbc.cc
@@ -299,60 +299,6 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
   return {};
 }
 
-// For handling .fir files (MLIR+FIR)
-std::string CompileFir(std::string path, Fortran::parser::Options options,
-    DriverOptions &driver,
-    Fortran::semantics::SemanticsContext &semanticsContext) {
-  Br::instantiateBurnsideBridge(semanticsContext.defaultKinds());
-
-  // check that there is a file to load
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> fileOrErr =
-      llvm::MemoryBuffer::getFileOrSTDIN(path);
-  if (std::error_code EC = fileOrErr.getError()) {
-    llvm::errs() << "Could not open file: " << EC.message() << '\n';
-    std::exit(-1);
-  }
-
-  // load the file into a module
-  llvm::SourceMgr sourceMgr;
-  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), llvm::SMLoc());
-  Br::getBridge().parseSourceFile(sourceMgr);
-  auto mlirModule = Br::getBridge().getModule();
-  if (!Br::getBridge().validModule()) {
-    llvm::errs() << "Error can't load file " << path << '\n';
-    std::exit(3);
-  }
-  if (mlir::failed(mlirModule.verify())) {
-    llvm::errs() << "Error verifying FIR module\n";
-    std::exit(4);
-  }
-
-  llvm::errs() << ";== 3 ==\n";
-  mlirModule.dump();
-
-  // run passes
-  mlir::PassManager pm{mlirModule.getContext()};
-  pm.addPass(fir::createMemToRegPass());
-  pm.addPass(fir::createCSEPass());
-  if (driver.lowerToStd) {
-    pm.addPass(fir::createFIRToStdPass());
-  }
-  if (driver.lowerToLLVM) {
-    pm.addPass(fir::createFIRToLLVMPass());
-  }
-  if (driver.lowerToLLVMIR) {
-    pm.addPass(fir::createLLVMDialectToLLVMPass("a.ll"));
-  }
-  if (mlir::succeeded(pm.run(mlirModule))) {
-    llvm::errs() << ";== 4 ==\n";
-    mlirModule.dump();
-  } else {
-    llvm::errs() << "FAILED\n";
-    std::exit(5);
-  }
-  return {};
-}
-
 std::string CompileOtherLanguage(std::string path, DriverOptions &driver) {
   std::string relo{RelocatableName(driver, path)};
   if (ParentProcess()) {
@@ -408,8 +354,7 @@ int main(int argc, char *const argv[]) {
 
   Fortran::common::IntrinsicTypeDefaultKinds defaultKinds;
 
-  std::vector<std::string> fortranSources, firSources, otherSources,
-      relocatables;
+  std::vector<std::string> fortranSources, otherSources, relocatables;
   bool anyFiles{false};
 
   while (!args.empty()) {
@@ -429,8 +374,6 @@ int main(int argc, char *const argv[]) {
             suffix == "cuf" || suffix == "CUF" || suffix == "f18" ||
             suffix == "F18" || suffix == "ff18") {
           fortranSources.push_back(arg);
-        } else if (suffix == "fir" || suffix == "ir" || suffix == "mlir") {
-          firSources.push_back(arg);
         } else if (suffix == "o" || suffix == "a") {
           relocatables.push_back(arg);
         } else {
@@ -619,12 +562,6 @@ int main(int argc, char *const argv[]) {
   }
   for (const auto &path : fortranSources) {
     std::string relo{CompileFortran(path, options, driver, semanticsContext)};
-    if (!driver.compileOnly && !relo.empty()) {
-      relocatables.push_back(relo);
-    }
-  }
-  for (const auto &path : firSources) {
-    std::string relo{CompileFir(path, options, driver, semanticsContext)};
     if (!driver.compileOnly && !relo.empty()) {
       relocatables.push_back(relo);
     }

--- a/tools/tco/CMakeLists.txt
+++ b/tools/tco/CMakeLists.txt
@@ -39,7 +39,7 @@ set(EXE_LIBS
   MLIRVectorToLLVM
 )
 
-add_llvm_executable(tco tco.cpp)
+add_llvm_tool(tco tco.cpp)
 llvm_update_compile_flags(tco)
 whole_archive_link(tco ${EXE_LIBS})
 target_link_libraries(tco PRIVATE FIR MLIRIR FirTcoLib ${EXE_LIBS} LLVMSupport)


### PR DESCRIPTION
I was not able to build f18 with the current instructions and the monorepo, I had to define `LLVM_EXTERNAL_PROJECTS`.

It seems to be because `flang` is not defined in `LLVM_ALL_PROJECTS` inside llvm monorepo CMakeLists.txt, so `flang` needs to be added to `LLVM_EXTERNAL_PROJECTS` in the cmake command to enable flang project during llvm build.