### PR TITLE
Propagate logicals values in the type required by consumers

### DIFF
--- a/lib/burnside/ast-builder.h
+++ b/lib/burnside/ast-builder.h
@@ -74,11 +74,11 @@ struct Evaluation {
   Evaluation(const A &a, const parser::CharBlock &pos,
       const std::optional<parser::Label> &lab)
     : u{&a}, ux{StmtExtra{pos, lab}} {
-    static_assert(!isConstruct(a) && "must be a statement");
-    if constexpr (isAction(a)) {
+    static_assert(!isConstruct<A>() && "must be a statement");
+    if constexpr (isAction<A>()) {
       isActionStmt = true;
     }
-    if constexpr (isAction(a) || isOther(a)) {
+    if constexpr (isAction<A>() || isOther<A>()) {
       isStatement = true;
     }
   }
@@ -86,12 +86,12 @@ struct Evaluation {
   /// Construct ctor
   template<typename A>
   Evaluation(const A &a) : u{&a}, ux{std::list<Evaluation>{}} {
-    static_assert(isConstruct(a) && "must be a construct");
+    static_assert(isConstruct<A>() && "must be a construct");
   }
 
   /// statements that are executable (actions)
-  template<typename A> constexpr static bool isAction(const A &a) {
-    if constexpr (!isConstruct(a) && !isOther(a)) {
+  template<typename A> constexpr static bool isAction() {
+    if constexpr (!isConstruct<A>() && !isOther<A>()) {
       return true;
     } else {
       return false;
@@ -99,7 +99,7 @@ struct Evaluation {
   }
 
   /// constructs (and directives)
-  template<typename A> constexpr static bool isConstruct(const A &) {
+  template<typename A> constexpr static bool isConstruct() {
     if constexpr (std::is_same_v<A, parser::AssociateConstruct> ||
         std::is_same_v<A, parser::BlockConstruct> ||
         std::is_same_v<A, parser::CaseConstruct> ||
@@ -121,7 +121,7 @@ struct Evaluation {
   }
 
   /// statements that are not executable
-  template<typename A> constexpr static bool isOther(const A &) {
+  template<typename A> constexpr static bool isOther() {
     if constexpr (std::is_same_v<A, parser::FormatStmt> ||
         std::is_same_v<A, parser::EntryStmt> ||
         std::is_same_v<A, parser::DataStmt> ||

--- a/lib/burnside/bridge.cc
+++ b/lib/burnside/bridge.cc
@@ -117,6 +117,10 @@ class FIRConverter {
     return createSomeExpression(
         loc, build(), *expr, symbolMap, defaults, intrinsics);
   }
+  M::Value *createLogicalExprAsI1(M::Location loc, const SomeExpr *expr) {
+    return createI1LogicalExpression(
+        loc, build(), *expr, symbolMap, defaults, intrinsics);
+  }
   M::Value *createTemp(M::Type type, Se::Symbol *symbol = nullptr) {
     return createTemporary(toLocation(), build(), symbolMap, type, symbol);
   }
@@ -516,7 +520,7 @@ class FIRConverter {
       const A &tuple, Fl::LabelMention trueLabel, Fl::LabelMention falseLabel) {
     auto *exprRef{Se::GetExpr(std::get<Pa::ScalarLogicalExpr>(tuple))};
     assert(exprRef && "condition expression missing");
-    auto *cond{createFIRExpr(toLocation(), exprRef)};
+    auto *cond{createLogicalExprAsI1(toLocation(), exprRef)};
     genCondBranch(cond, trueLabel, falseLabel);
   }
   void genFIR(const Pa::Statement<Pa::IfThenStmt> &stmt,
@@ -561,7 +565,7 @@ class FIRConverter {
               [&](const parser::ScalarLogicalExpr &logical) {
                 auto loc{toLocation(stmt.source)};
                 auto *exp{Se::GetExpr(logical)};
-                condition = createFIRExpr(loc, exp);
+                condition = createLogicalExprAsI1(loc, exp);
                 return false;
               },
               [&](const parser::LoopControl::Concurrent &concurrent) {
@@ -583,6 +587,7 @@ class FIRConverter {
 
   // Action statements
   void genFIR(const Pa::AllocateStmt &stmt) { TODO(); }
+
   void genFIR(const Pa::AssignmentStmt &stmt) {
     auto *rhs{Se::GetExpr(std::get<Pa::Expr>(stmt.t))};
     auto *lhs{Se::GetExpr(std::get<Pa::Variable>(stmt.t))};

--- a/lib/burnside/convert-expr.h
+++ b/lib/burnside/convert-expr.h
@@ -50,6 +50,12 @@ mlir::Value *createSomeExpression(mlir::Location loc, mlir::OpBuilder &builder,
     evaluate::Expr<evaluate::SomeType> const &expr, SymMap &symMap,
     common::IntrinsicTypeDefaultKinds const &defaults,
     IntrinsicLibrary const &intrinsics);
+
+mlir::Value *createI1LogicalExpression(mlir::Location loc,
+    mlir::OpBuilder &builder, evaluate::Expr<evaluate::SomeType> const &expr,
+    SymMap &symMap, common::IntrinsicTypeDefaultKinds const &defaults,
+    IntrinsicLibrary const &intrinsics);
+
 mlir::Value *createSomeAddress(mlir::Location loc, mlir::OpBuilder &builder,
     evaluate::Expr<evaluate::SomeType> const &expr, SymMap &symMap,
     common::IntrinsicTypeDefaultKinds const &defaults,

--- a/lib/burnside/convert-type.cc
+++ b/lib/burnside/convert-type.cc
@@ -388,3 +388,7 @@ M::Type Br::translateSymbolToFIRType(M::MLIRContext *context,
 M::Type Br::convertReal(M::MLIRContext *context, int kind) {
   return genFIRType<RealCat>(context, kind);
 }
+
+M::Type Br::getMLIRlogicalType(M::MLIRContext *context) {
+  return M::IntegerType::get(1, context);
+}

--- a/lib/burnside/convert-type.h
+++ b/lib/burnside/convert-type.h
@@ -107,7 +107,9 @@ mlir::Type translateSymbolToFIRType(mlir::MLIRContext *ctxt,
     common::IntrinsicTypeDefaultKinds const &defaults,
     const semantics::SymbolRef symbol);
 
-mlir::Type convertReal(mlir::MLIRContext *context, int KIND);
+mlir::Type convertReal(mlir::MLIRContext *ctxt, int KIND);
+
+mlir::Type getMLIRlogicalType(mlir::MLIRContext *ctxt);
 
 }  // burnside
 }  // Fortran


### PR DESCRIPTION
This PR:
- Changes the ways logical are handled in the bridge  (core of the PR)
- Fixes a constant expression issue that came from last rebase with AST changes (not central, just to pass the build with clang).


Inside the `ExprLowering` facility:
- After evaluating an `Expr<Type<Logical, KIND>>` expression, convert the result to the type requested by the consumer of the expression if needed.
- A state `genLogicalAsI1` is added to `ExprLowering` facility. It allows to propagate the final consumer type through nodes where the type manipulated does not matter (e.g. parantheses) while also allowing a node of a tree to locally change the requested type to produce its logical operands.

At the external interface of `ExprLowering` facility:
- Add `createI1LogicalExpression` external methods that can be used to the bridge.
- The default expression generation `createSomeExpression` generate `fir.logical` which is what is needed in assignments and calls  as well as in weird intrinsics (TRANSFER) where the physical representation matters.

This design fulfills:
- It will be possible to lower `TRANSFER(TRANSFER(int, logical))` in such as it still evaluate to `int` as requested by 16.9.193.
- It avoids generating useless conversions in the middle of logical operations such as `if(x.le.y.AND.x.gt.z) then ...`
- It has a "low" footprint on the rest of the bridge. Parts that handle logical expressions without caring about what it is do not have to add code to handle the FIR/MLIR type possibilities.

Also addresses #16 comments
- Add assert message for `.NOT.`.
- Move `getMLIRLogicaType` to `convert-type.h`.