### PR TITLE
Address PR17 review comments and control logical argument type

### DIFF
--- a/lib/burnside/convert-type.cc
+++ b/lib/burnside/convert-type.cc
@@ -388,7 +388,3 @@ M::Type Br::translateSymbolToFIRType(M::MLIRContext *context,
 M::Type Br::convertReal(M::MLIRContext *context, int kind) {
   return genFIRType<RealCat>(context, kind);
 }
-
-M::Type Br::getMLIRlogicalType(M::MLIRContext *context) {
-  return M::IntegerType::get(1, context);
-}

--- a/lib/burnside/convert-type.h
+++ b/lib/burnside/convert-type.h
@@ -109,8 +109,6 @@ mlir::Type translateSymbolToFIRType(mlir::MLIRContext *ctxt,
 
 mlir::Type convertReal(mlir::MLIRContext *ctxt, int KIND);
 
-mlir::Type getMLIRlogicalType(mlir::MLIRContext *ctxt);
-
 }  // burnside
 }  // Fortran
 


### PR DESCRIPTION
Address https://github.com/schweitzpgi/f18/pull/17 comments:
- Rename `genMLIRLogicalConstant` to `genLogicalConstantAsI1`
- Add assert that Fortran function calls have a single result in MLIR
- Editorial changes

Also apply logical type control around intrinsic and user function calls.