### PR TITLE
Implement substring and CHARACTER(*) assignment lowering

### DIFF
--- a/lib/lower/convert-type.cc
+++ b/lib/lower/convert-type.cc
@@ -488,3 +488,11 @@ M::FunctionType Br::translateSymbolToFIRFunctionType(
 M::Type Br::convertReal(M::MLIRContext *context, int kind) {
   return genFIRType<RealCat>(context, kind);
 }
+
+M::Type Br::getSequenceRefType(M::Type refType) {
+  auto type{refType.dyn_cast<fir::ReferenceType>()};
+  assert(type && "expected a reference type");
+  auto elementType{type.getEleTy()};
+  fir::SequenceType::Shape shape{-1};
+  return fir::ReferenceType::get(fir::SequenceType::get(shape, elementType));
+}

--- a/lib/lower/convert-type.h
+++ b/lib/lower/convert-type.h
@@ -115,6 +115,13 @@ mlir::FunctionType translateSymbolToFIRFunctionType(
 
 mlir::Type convertReal(mlir::MLIRContext *ctxt, int KIND);
 
+// Given a ReferenceType of a base type, returns the ReferenceType to
+// the SequenceType of this base type.
+// The created SequenceType has one dimension of unknown extent.
+// This is useful to do pointer arithmetic using fir::CoordinateOp that requires
+// a memory reference to a sequence type.
+mlir::Type getSequenceRefType(mlir::Type referenceType);
+
 } // namespace lower
 } // namespace Fortran
 


### PR DESCRIPTION
- Lower `Ev::DescriptorInquiry` (only for inquiry about length of assumed character length (i.e. descriptor is a `fir::boxchar`)).

- Lower `Ev::Substring` address computation