### PR TITLE
Use std::unique_ptr for IntrinsicLibrary implementation

### DIFF
--- a/lib/lower/bridge.cc
+++ b/lib/lower/bridge.cc
@@ -560,21 +560,7 @@ class FirConverter : public AbstractConverter {
   void genFIR(const Pa::BlockConstruct &) { TODO(); }
   void genFIR(const Pa::ChangeTeamConstruct &) { TODO(); }
   void genFIR(const Pa::CriticalConstruct &) { TODO(); }
-  void genFIR(const Pa::DoConstruct &d) {
-#if 0
-    auto &stmt{std::get<Pa::Statement<Pa::NonLabelDoStmt>>(d.t)};
-    const Pa::NonLabelDoStmt &ss{stmt.statement};
-    auto &ctrl{std::get<std::optional<Pa::LoopControl>>(ss.t)};
-    if (ctrl.has_value()) {
-      // std::visit([&](const auto &x) { genLoopEnterFIR(x, &ss, stmt.source);
-      // }, ctrl->u);
-    } else {
-      // loop forever (See 11.1.7.4.1, para. 2)
-      // pushDoContext(&ss);
-    }
-#endif
-    TODO();
-  }
+  void genFIR(const Pa::DoConstruct &) { TODO(); }
   void genFIR(const Pa::IfConstruct &) { TODO(); }
 
   void genFIR(const SelectCaseConstruct &) { TODO(); }
@@ -1186,8 +1172,8 @@ public:
   explicit FirConverter(BurnsideBridge &bridge, fir::NameUniquer &uniquer)
       : mlirContext{bridge.getMLIRContext()}, cooked{bridge.getCookedSource()},
         module{bridge.getModule()}, defaults{bridge.getDefaultKinds()},
-        intrinsics{IntrinsicLibrary::create(IntrinsicLibrary::Version::LLVM,
-                                            bridge.getMLIRContext())},
+        intrinsics{IntrinsicLibrary(IntrinsicLibrary::Version::LLVM,
+                                    bridge.getMLIRContext())},
         uniquer{uniquer} {}
 
   /// Convert the AST to FIR

--- a/lib/lower/convert-expr.cc
+++ b/lib/lower/convert-expr.cc
@@ -61,9 +61,6 @@ class ExprLowering {
   M::OpBuilder &builder;
   SomeExpr const &expr;
   SymMap &symMap;
-#if 0
-  SymMap loadedSymbols;
-#endif
   IntrinsicLibrary const &intrinsics;
   bool genLogicalAsI1{false};
 
@@ -254,24 +251,11 @@ class ExprLowering {
   M::Value gendef(Se::SymbolRef sym) { return gen(sym); }
 
   M::Value genval(Se::SymbolRef sym) {
-#if 0
-    // Do not load the same symbols several time in one expression.
-    // Fortran guarantees variable value must be the same wherever it
-    // appears in one expression.
-    if (mlir::Value loaded = loadedSymbols.lookupSymbol(sym)) 
-      return loaded;
-    mlir::Value load = builder.create<fir::LoadOp>(getLoc(), gen(sym));
-    loadedSymbols.addSymbol(sym, load);
-    return load;
-#else
-    // Multiple loads should be CSEd. If they aren't, it's a bug in CSE that
-    // should not use a workaround here.
     auto var = gen(sym);
     if (fir::isReferenceLike(var->getType())) {
       return builder.create<fir::LoadOp>(getLoc(), var);
     }
     return var;
-#endif
   }
 
   M::Value genval(Ev::BOZLiteralConstant const &) { TODO(); }

--- a/lib/lower/intrinsics.cc
+++ b/lib/lower/intrinsics.cc
@@ -276,14 +276,10 @@ static constexpr MathsRuntimeStaticDescription pgmathPreciseRuntime[] = {
 
 // IntrinsicLibrary implementation
 
-IntrinsicLibrary IntrinsicLibrary::create(IntrinsicLibrary::Version v,
-                                          M::MLIRContext &context) {
-  IntrinsicLibrary lib{};
-  lib.impl = new Implementation(v, context);
-  return lib;
-}
-
-IntrinsicLibrary::~IntrinsicLibrary() { delete impl; }
+IntrinsicLibrary::IntrinsicLibrary(IntrinsicLibrary::Version v,
+                                   M::MLIRContext &context)
+    : impl{new Implementation(v, context)} {}
+IntrinsicLibrary::~IntrinsicLibrary() = default;
 
 M::Value IntrinsicLibrary::genval(M::Location loc, M::OpBuilder &builder,
                                   L::StringRef name, M::Type resultType,

--- a/lib/lower/intrinsics.h
+++ b/lib/lower/intrinsics.h
@@ -11,6 +11,7 @@
 
 #include "mlir/Dialect/StandardOps/Ops.h"
 #include "llvm/ADT/StringRef.h"
+#include <memory>
 #include <optional>
 
 /// [Coding style](https://llvm.org/docs/CodingStandards.html)
@@ -38,6 +39,8 @@ public:
   /// Available runtime library versions.
   enum class Version { PgmathFast, PgmathRelaxed, PgmathPrecise, LLVM };
 
+  /// Create an IntrinsicLibrary targeting the desired runtime library version.
+  IntrinsicLibrary(Version, mlir::MLIRContext &);
   ~IntrinsicLibrary();
   /// Generate the FIR+MLIR operations for the generic intrinsic "name".
   /// On failure, returns a nullptr, else the returned mlir::Value is
@@ -54,13 +57,10 @@ public:
   // TODO: Error handling interface ?
   // TODO: Implementation is incomplete. Many intrinsics to tbd.
 
-  /// Create an IntrinsicLibrary targeting the desired runtime library version.
-  static IntrinsicLibrary create(Version, mlir::MLIRContext &);
-
 private:
   /// Actual implementation is hidden.
   class Implementation;
-  Implementation *impl{nullptr}; // owning pointer
+  std::unique_ptr<Implementation> impl;
 };
 
 } // namespace Fortran::lower


### PR DESCRIPTION
Answer some comments from https://github.com/flang-compiler/f18/pull/920:
- Use std::unique_ptr for `IntrinsicLibrary::Implementation` instead of a simple "owning pointer" comment.
- Remove two `#if 0` dead code pieces