### PR TITLE
Make flang lit test run with in-tree builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Or, of course, use their favorite build tool (such as ninja).
   cd build
   export CC=<my-favorite-C-compiler>
   export CXX=<my-favorite-C++-compiler>
-  cmake -GNinja ../f18-llvm-project/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_PROJECTS=mlir -DCMAKE_CXX_STANDARD=17 -DLLVM_BUILD_TOOLS=On -DCMAKE_INSTALL_PREFIX=<install-llvm-here> <other-arguments>
+  cmake -GNinja ../f18-llvm-project/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_PROJECTS=mlir -DCMAKE_CXX_STANDARD=17 -DLLVM_BUILD_TOOLS=On -DLLVM_INSTALL_UTILS=On -DCMAKE_INSTALL_PREFIX=<install-llvm-here> <other-arguments>
 ```
 
 5. Build and install
@@ -92,6 +92,11 @@ Or, of course, use their favorite build tool (such as ninja).
   cd build-flang
   cmake -GNinja ../f18 -DLLVM_DIR=<install-llvm-here> -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_CXX_STANDARD=17 -DLLVM_BUILD_TOOLS=On -DCMAKE_INSTALL_PREFIX=<install-flang-here> <other-arguments>
 ```
+Note: if you plan on running lit regression tests, you should either:
+- Use `-DLLVM_DIR=<build-llvm-here>` instead of `-DLLVM_DIR=<install-llvm-here>`
+- Or, keep `-DLLVM_DIR=<install-llvm-here>` but add `-DLLVM_EXTERNAL_LIT=<path to llvm-lit>`.
+A valid `llvm-lit` path is `<build-llvm-here>/bin/llvm-lit`.
+Note that LLVM must also have been built with `-DLLVM_INSTALL_UTILS=On` so that tools required by tests like `FileCheck` are available in `<install-llvm-here>`.
 
 8. Build and install
 
@@ -99,6 +104,16 @@ Or, of course, use their favorite build tool (such as ninja).
   ninja
   ninja install
 ```
+
+### Running regression tests
+
+Inside `build` for in-tree builds or inside `build-flang` for out-of-tree builds:
+
+```
+  ninja check-flang
+```
+
+Special CMake instructions given above are required while building out-of-tree so that lit regression tests can be run.
 
 ### Problems
 

--- a/test-lit/CMakeLists.txt
+++ b/test-lit/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Test runner infrastructure for Flang. This configures the Flang test trees
 # for use by Lit, and delegates to LLVM's lit test handlers.
 
+set(FLANG_TOOLS_DIR  ${FLANG_BINARY_DIR}/tools/f18/bin)
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
@@ -32,4 +34,3 @@ set_target_properties(check-flang PROPERTIES FOLDER "Tests")
 add_lit_testsuites(FLANG ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${FLANG_TEST_DEPS}
 )
-set(FLANG_TOOLS_DIR  ${FLANG_BINARY_DIR}/tools/f18/bin)

--- a/test-lit/CMakeLists.txt
+++ b/test-lit/CMakeLists.txt
@@ -1,7 +1,14 @@
 # Test runner infrastructure for Flang. This configures the Flang test trees
 # for use by Lit, and delegates to LLVM's lit test handlers.
 
+# f18/flang tools path for lit
 set(FLANG_TOOLS_DIR  ${FLANG_BINARY_DIR}/tools/f18/bin)
+# bbc/tco tools path for lit
+if (FLANG_BUILT_STANDALONE)
+ set(FLANG_LLVM_TOOLS_DIR  ${FLANG_BINARY_DIR}/bin)
+else()
+ set(FLANG_LLVM_TOOLS_DIR  ${LLVM_BINARY_DIR}/bin)
+endif()
 
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in

--- a/test-lit/lit.cfg.py
+++ b/test-lit/lit.cfg.py
@@ -28,7 +28,7 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.f', '.F', '.ff','.FOR', '.for', '.f77', '.f90', '.F90',
                    '.ff90', '.f95', '.F95', '.ff95', '.fpp', '.FPP', '.cuf',
-                   '.CUF', '.f18', '.F18']
+                   '.CUF', '.f18', '.F18', '.fir' ]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)

--- a/test-lit/lit.cfg.py
+++ b/test-lit/lit.cfg.py
@@ -55,6 +55,10 @@ config.test_exec_root = os.path.join(config.flang_obj_root, 'test-lit')
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.flang_tools_dir, append_path=True)
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+# For out-of-tree builds, path to bbc and tco needs to be added
+
+if config.llvm_tools_dir != config.flang_llvm_tools_dir :
+  llvm_config.with_environment('PATH', config.flang_llvm_tools_dir, append_path=True)
 
 # For each occurrence of a flang tool name, replace it with the full path to
 # the build directory holding that tool.  We explicitly specify the directories

--- a/test-lit/lit.site.cfg.py.in
+++ b/test-lit/lit.site.cfg.py.in
@@ -6,6 +6,7 @@ config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
 config.flang_obj_root = "@FLANG_BINARY_DIR@"
 config.flang_src_dir = "@FLANG_SOURCE_DIR@"
 config.flang_tools_dir = "@FLANG_TOOLS_DIR@"
+config.flang_llvm_tools_dir = "@FLANG_LLVM_TOOLS_DIR@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 
 # Support substitution of the tools_dir with user parameters. This is


### PR DESCRIPTION
- Fix flang path to export to lit config
- Add ".fir" extension in lit config to be considered as tests.

Tested with in-tree builds, it will probably still not work with out-of-tree builds due to llvm-lit paths issues.
PS: the result of the fir tests is a failure, but that is an actual know issue (not a test issue).