### PR TITLE
Solve some PR1035

### DIFF
--- a/include/flang/Optimizer/Dialect/FIRAttr.h
+++ b/include/flang/Optimizer/Dialect/FIRAttr.h
@@ -119,7 +119,7 @@ public:
   }
 };
 
-/// A pointer interval is an closed interval as given as an ssa-value. The
+/// A pointer interval is a closed interval as given as an ssa-value. The
 /// interval contains exactly one value.
 /// A case selector of `CASE (p)` corresponds to exactly the value `p` and is
 /// encoded as `#fir.point, %p`.

--- a/include/flang/Optimizer/Dialect/FIROps.h
+++ b/include/flang/Optimizer/Dialect/FIROps.h
@@ -16,8 +16,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
-using namespace mlir;
-
 namespace fir {
 
 class FirEndOp;
@@ -55,7 +53,8 @@ void buildCmpFOp(mlir::Builder *builder, mlir::OperationState &result,
                  CmpFPredicate predicate, mlir::Value lhs, mlir::Value rhs);
 void buildCmpCOp(mlir::Builder *builder, mlir::OperationState &result,
                  CmpFPredicate predicate, mlir::Value lhs, mlir::Value rhs);
-unsigned getCaseArgumentOffset(ArrayRef<mlir::Attribute> cases, unsigned dest);
+unsigned getCaseArgumentOffset(llvm::ArrayRef<mlir::Attribute> cases,
+                               unsigned dest);
 LoopOp getForInductionVarOwner(mlir::Value val);
 bool isReferenceLike(mlir::Type type);
 mlir::ParseResult isValidCaseAttr(mlir::Attribute attr);
@@ -68,6 +67,8 @@ mlir::ParseResult parseSelector(mlir::OpAsmParser &parser,
                                 mlir::OpAsmParser::OperandType &selector,
                                 mlir::Type &type);
 
+// Sources generated with tablegen require mlir namespace to be accessible.
+using namespace mlir;
 #define GET_OP_CLASSES
 #include "flang/Optimizer/Dialect/FIROps.h.inc"
 

--- a/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -21,21 +21,19 @@ inline bool nonVolatileLoad(mlir::Operation *op) {
   return false;
 }
 
+/// return true iff the Operation is a call
+inline bool isaCall(mlir::Operation *op) {
+  return isa<fir::CallOp>(op) || isa<fir::DispatchOp>(op) ||
+         isa<mlir::CallOp>(op) || isa<mlir::CallIndirectOp>(op);
+}
+
 /// return true iff the Operation is a fir::CallOp, fir::DispatchOp,
 /// mlir::CallOp, or mlir::CallIndirectOp and not pure
 /// NB: this is not the same as `!pureCall(op)`
 inline bool impureCall(mlir::Operation *op) {
   // Should we also auto-detect that the called function is pure if its
   // arguments are not references?  For now, rely on a "pure" attribute.
-  if (auto call = dyn_cast<fir::CallOp>(op))
-    return !call.getAttr("pure");
-  if (auto dispatch = dyn_cast<fir::DispatchOp>(op))
-    return !dispatch.getAttr("pure");
-  if (auto call = dyn_cast<mlir::CallOp>(op))
-    return !call.getAttr("pure");
-  if (auto icall = dyn_cast<mlir::CallIndirectOp>(op))
-    return !icall.getAttr("pure");
-  return false;
+  return op && isaCall(op) && !op->getAttr("pure");
 }
 
 /// return true iff the Operation is a fir::CallOp, fir::DispatchOp,
@@ -44,15 +42,7 @@ inline bool impureCall(mlir::Operation *op) {
 inline bool pureCall(mlir::Operation *op) {
   // Should we also auto-detect that the called function is pure if its
   // arguments are not references?  For now, rely on a "pure" attribute.
-  if (auto call = dyn_cast<fir::CallOp>(op))
-    return bool(call.getAttr("pure"));
-  if (auto dispatch = dyn_cast<fir::DispatchOp>(op))
-    return bool(dispatch.getAttr("pure"));
-  if (auto call = dyn_cast<mlir::CallOp>(op))
-    return bool(call.getAttr("pure"));
-  if (auto icall = dyn_cast<mlir::CallIndirectOp>(op))
-    return bool(icall.getAttr("pure"));
-  return false;
+  return op && isaCall(op) && op->getAttr("pure");
 }
 
 /// Get or create a FuncOp in a module.

--- a/include/flang/Optimizer/Support/KindMapping.h
+++ b/include/flang/Optimizer/Support/KindMapping.h
@@ -10,8 +10,8 @@
 #define OPTIMIZER_SUPPORT_KINDMAPPING_H
 
 #include "mlir/IR/OpDefinition.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/Type.h"
-#include <unordered_map>
 
 namespace llvm {
 template <typename>
@@ -81,8 +81,8 @@ private:
   MatchResult parse(llvm::StringRef kindMap);
 
   mlir::MLIRContext *context;
-  std::unordered_map<char, std::unordered_map<KindTy, Bitsize>> intMap;
-  std::unordered_map<char, std::unordered_map<KindTy, LLVMTypeID>> floatMap;
+  llvm::DenseMap<char, llvm::DenseMap<KindTy, Bitsize>> intMap;
+  llvm::DenseMap<char, llvm::DenseMap<KindTy, LLVMTypeID>> floatMap;
 };
 
 } // namespace fir

--- a/lib/Optimizer/Support/KindMapping.cpp
+++ b/lib/Optimizer/Support/KindMapping.cpp
@@ -54,10 +54,9 @@ static LLVMTypeID defaultRealKind(KindTy kind) {
 
 // lookup the kind-value given the defaults, the mappings, and a KIND key
 template <typename RT, char KEY>
-static RT
-doLookup(std::function<RT(KindTy)> def,
-         const std::unordered_map<char, std::unordered_map<KindTy, RT>> &map,
-         KindTy kind) {
+static RT doLookup(std::function<RT(KindTy)> def,
+                   const llvm::DenseMap<char, llvm::DenseMap<KindTy, RT>> &map,
+                   KindTy kind) {
   auto iter = map.find(KEY);
   if (iter != map.end()) {
     auto iter2 = iter->second.find(kind);


### PR DESCRIPTION
I was not able to test these answers to some of David's comment yet (unrelated build issues), so I am pushing these here first.

I am not 100% sure that the second commit changes are OK. I did them to test:
- [std::unordered_map -> llvm::DenseMap](https://github.com/flang-compiler/f18/pull/1035#discussion_r386942281) (I do not see big issues here)

- [impureCall/isCall refactoring](https://github.com/flang-compiler/f18/pull/1035#discussion_r386934370) (My understanding is that querying the attributes is unrelated to whether the op was dyn_cast before or not but I am not 100% sure it is equivalent)

To sum-up: This addresses all the comment I answered to in the thread, + the two above where I did not answered yet because I was not sure. I have not covered all the other un-answered comments.



