### PR TITLE
Standalone cmake definition fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include(AddFlang)
 
 
 # Check for a standalone build and configure as appropriate from
-# there. 
+# there.
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   message("Building Flang as a standalone project.")
   project(Flang)
@@ -49,7 +49,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     mark_as_advanced(LLVM_ENABLE_ASSERTIONS)
   endif()
 
-  # We need a pre-built/installed version of LLVM. 
+  # We need a pre-built/installed version of LLVM.
   find_package(LLVM REQUIRED HINTS "${LLVM_CMAKE_PATH}")
   list(APPEND CMAKE_MODULE_PATH ${LLVM_DIR})
 
@@ -58,12 +58,16 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     find_package(ZLIB REQUIRED)
   endif()
 
+  # They are used as destination of target generators.
+  set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin)
+  set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX})
+
   include(CMakeParseArguments)
   include(AddLLVM)
-  include(HandleLLVMOptions)  
+  include(HandleLLVMOptions)
   include(VersionFromVCS)
   include(TableGen)
-  include(AddMLIR) 
+  include(AddMLIR)
 
   option(LLVM_ENABLE_WARNINGS "Enable compiler warnings." ON)
   option(LLVM_INSTALL_TOOLCHAIN_ONLY
@@ -71,7 +75,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   option(LLVM_FORCE_USE_OLD_HOST_TOOLCHAIN
     "Set to ON to force using an old, unsupported host toolchain." OFF)
 
-  
+
   # Add LLVM include files as if they were SYSTEM because there are complex unused
   # parameter issues that may or may not appear depending on the environments and
   # compilers (ifdefs are involved). This allows warnings from LLVM headers to be

--- a/test-lit/CMakeLists.txt
+++ b/test-lit/CMakeLists.txt
@@ -8,11 +8,7 @@ set(FLANG_INTRINSIC_MODULES_DIR ${FLANG_BINARY_DIR}/include/flang)
 set(FLANG_TOOLS_DIR  ${FLANG_BINARY_DIR}/tools/f18/bin)
 
 # bbc/tco tools path for lit
-if (FLANG_BUILT_STANDALONE)
- set(FLANG_LLVM_TOOLS_DIR  ${FLANG_BINARY_DIR}/bin)
-else()
- set(FLANG_LLVM_TOOLS_DIR  ${LLVM_BINARY_DIR}/bin)
-endif()
+set(FLANG_LLVM_TOOLS_DIR  ${FLANG_BINARY_DIR}/bin)
 
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in

--- a/test-lit/lit.site.cfg.py.in
+++ b/test-lit/lit.site.cfg.py.in
@@ -2,7 +2,7 @@
 
 import sys
 
-config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_BINARY_DIR@"
 config.flang_obj_root = "@FLANG_BINARY_DIR@"
 config.flang_src_dir = "@FLANG_SOURCE_DIR@"
 config.flang_tools_dir = "@FLANG_TOOLS_DIR@"


### PR DESCRIPTION
- Fix clang + gnu ld `undefined reference to `main'` issue
- Fix paths to tco and bbc tools given to lit for out-of-tree builds