### PR TITLE
Character Lowering update + Specification expression lowering skeleton

### DIFF
--- a/lib/Semantics/tools.cpp
+++ b/lib/Semantics/tools.cpp
@@ -310,6 +310,7 @@ bool IsProcedure(const Symbol &symbol) {
           [](const GenericDetails &) { return true; },
           [](const ProcBindingDetails &) { return true; },
           [](const UseDetails &x) { return IsProcedure(x.symbol()); },
+          [](const HostAssocDetails &x) { return IsProcedure(x.symbol()); },
           // TODO: FinalProcDetails?
           [](const auto &) { return false; },
       },

--- a/not-test/lower/test_character_assignment.sh
+++ b/not-test/lower/test_character_assignment.sh
@@ -26,7 +26,7 @@ testObject=test.o
 testExec=./test_exec
 testLog=test.log
 llFile=a.mlir.ll
-$BBC -emit-llvm -disable-fir2std $F_SRC 2>$bbcLog
+$BBC -emit-llvm -disable-fir2std -o a.mlir $F_SRC 2>$bbcLog
 [[ $? -ne 0 ]] && die "bbc test.f90 compilation failure"
 sed -i 's/_QP//g' -i $llFile
 $LLC $llFile -o $assembly

--- a/test/Lower/pre-fir-tree02.f90
+++ b/test/Lower/pre-fir-tree02.f90
@@ -157,7 +157,7 @@ contains
   function foo(x)
     real x(..)
     integer :: foo
-    ! CHECK: <<SelectRankConstruct>>
+    ! CHECK: <<SelectRankConstruct!>>
     ! CHECK: SelectRankStmt
     select rank(x)
       ! CHECK: SelectRankCaseStmt
@@ -178,7 +178,7 @@ contains
         foo = 2
     ! CHECK: EndSelectStmt
     end select
-    ! CHECK: <<End SelectRankConstruct>>
+    ! CHECK: <<End SelectRankConstruct!>>
   end function
 
   ! CHECK: Function bar


### PR DESCRIPTION
Go through function unit scope symbols and evaluate specification
expression before starting execution statements.

Current implementation only evaluate character length expression, and
hard TODO are added for other specification expressions.

CharacterOpsBuilder interface is cleaned up to support gettig stringLit.
Helper functions are also used in IO.cpp.