### PR TITLE
fixes after rebase with f18 5b89dc7 head

### DIFF
--- a/include/flang/Semantics/symbol.h
+++ b/include/flang/Semantics/symbol.h
@@ -59,14 +59,6 @@ private:
 
 class SubprogramDetails {
 public:
-  SubprogramDetails() {}
-  SubprogramDetails(const SubprogramDetails &that)
-    : dummyArgs_{that.dummyArgs_}, result_{that.result_} {}
-  SubprogramDetails &operator=(const SubprogramDetails &) = delete;
-  ~SubprogramDetails() = default;
-  SubprogramDetails &operator=(SubprogramDetails &&) = default;
-  SubprogramDetails(SubprogramDetails &&) = default;
-
   bool isFunction() const { return result_ != nullptr; }
   bool isInterface() const { return isInterface_; }
   void set_isInterface(bool value = true) { isInterface_ = value; }
@@ -743,10 +735,11 @@ inline bool ProcEntityDetails::HasExplicitInterface() const {
 
 inline bool operator<(SymbolRef x, SymbolRef y) { return *x < *y; }
 using SymbolSet = std::set<SymbolRef>;
+} // namespace Fortran::semantics
 
 // Define required  info so that SymbolRef can be used inside llvm::DenseMap.
 namespace llvm {
-template<> struct DenseMapInfo<Fortran::semantics::SymbolRef> {
+template <> struct DenseMapInfo<Fortran::semantics::SymbolRef> {
   static inline Fortran::semantics::SymbolRef getEmptyKey() {
     auto ptr = DenseMapInfo<const Fortran::semantics::Symbol *>::getEmptyKey();
     return *reinterpret_cast<Fortran::semantics::SymbolRef *>(&ptr);
@@ -768,6 +761,5 @@ template<> struct DenseMapInfo<Fortran::semantics::SymbolRef> {
     return LHS == RHS;
   }
 };
-
-} // namespace Fortran::semantics
-#endif  // FORTRAN_SEMANTICS_SYMBOL_H_
+} // namespace llvm
+#endif // FORTRAN_SEMANTICS_SYMBOL_H_

--- a/runtime/io-api.h
+++ b/runtime/io-api.h
@@ -27,10 +27,9 @@ using Cookie = IoStatementState *;
 using ExternalUnit = int;
 using AsynchronousId = int;
 static constexpr ExternalUnit DefaultUnit{-1}; // READ(*), WRITE(*), PRINT
-}
+} // namespace Fortran::runtime::io
 
-using namespace Fortran::runtime;
-using namespace Fortran::runtime::io;
+namespace Fortran::runtime::io {
 
 extern "C" {
 
@@ -296,6 +295,7 @@ bool IONAME(InquireInteger64)(
 // rather than by terminating the image.
 enum Iostat IONAME(EndIoStatement)(Cookie);
 
-}  // extern "C"
+} // extern "C"
+} // namespace Fortran::runtime::io
 
 #endif

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -66,7 +66,7 @@ if config.flang_llvm_tools_dir != "" :
     llvm_config.with_environment('PATH', config.flang_llvm_tools_dir, append_path=True)
 
 config.substitutions.append(('%B', config.flang_obj_root))
-config.substitutions.append(("%L", config.llvm_lib_dir))
+config.substitutions.append(("%L", config.flang_lib_dir))
 
 # For each occurrence of a flang tool name, replace it with the full path to
 # the build directory holding that tool.  We explicitly specify the directories

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -3,12 +3,11 @@
 import sys
 
 config.llvm_tools_dir = "@LLVM_TOOLS_BINARY_DIR@"
-config.llvm_lib_dir = "@LLVM_LIBS_DIR@"
 config.flang_obj_root = "@FLANG_BINARY_DIR@"
 config.flang_src_dir = "@FLANG_SOURCE_DIR@"
 config.flang_tools_dir = "@FLANG_TOOLS_DIR@"
 config.flang_intrinsic_modules_dir = "@FLANG_INTRINSIC_MODULES_DIR@"
-#config.flang_llvm_tools_dir = "@LLVM_RUNTIME_OUTPUT_INTDIR@"
+config.flang_lib_dir = "@FLANG_BINARY_DIR@/lib"
 config.flang_llvm_tools_dir = "@FLANG_LLVM_TOOLS_DIR@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -1,6 +1,3 @@
-file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
-file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
-
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
 
 add_llvm_tool(f18
@@ -41,11 +38,15 @@ foreach(filename ${MODULES})
     set(depends ${include}/__fortran_builtins.mod)
   endif()
   add_custom_command(OUTPUT ${include}/${filename}.mod
-    COMMAND f18 -fparse-only -fdebug-semantics -I${include}
+    COMMAND f18 -fparse-only -I${include}
       ${FLANG_SOURCE_DIR}/module/${filename}.f90
     WORKING_DIRECTORY ${include}
     DEPENDS f18 ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${depends}
   )
+  add_custom_command(OUTPUT ${include}/${filename}.f18.mod
+    DEPENDS ${include}/${filename}.mod
+    COMMAND ${CMAKE_COMMAND} -E
+      copy ${include}/${filename}.mod ${include}/${filename}.f18.mod)
   list(APPEND MODULE_FILES ${include}/${filename}.mod)
   list(APPEND MODULE_FILES ${include}/${filename}.f18.mod)
   install(FILES ${include}/${filename}.mod DESTINATION include/flang)


### PR DESCRIPTION
Here are fixes for regressions I faced after the rebase.
Every tests now passes for me gcc out-of-tree and clang + libstdc++.
hello.f90 has issues with clang + libc++ builds  because the tests link to lstdc++ (at least when clang is not the default machine compiler, maybe this works on mac out of the box). I could not find a nice why to handle this without adding cmake complexity. Anyway, I did not fight because the issue is with the runtime that should not pull in libstdc++ to begin with (it's a regression after f18 changes to build on windows and changes to use llvm:raw_stream everywhere in f18).
