### PR TITLE
fix in-tree build hello.f90 test failure

### DIFF
--- a/not-test/lower/test_expression_lowering.sh
+++ b/not-test/lower/test_expression_lowering.sh
@@ -29,7 +29,7 @@ assembly=a.s
 testObject=test.o
 testExec=./test_exec
 testLog=test.log
-llFile=a.mlir.ll
+llFile=test.mlir.ll
 
 $CPP $SRC -std=c++17 -o $testGen
 [[ $? -ne 0 ]] && die "test generator compilation failure"

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -7,8 +7,8 @@ config.flang_obj_root = "@FLANG_BINARY_DIR@"
 config.flang_src_dir = "@FLANG_SOURCE_DIR@"
 config.flang_tools_dir = "@FLANG_TOOLS_DIR@"
 config.flang_intrinsic_modules_dir = "@FLANG_INTRINSIC_MODULES_DIR@"
-config.flang_lib_dir = "@FLANG_BINARY_DIR@/lib"
-config.flang_llvm_tools_dir = "@FLANG_LLVM_TOOLS_DIR@"
+config.flang_lib_dir = "@LLVM_LIBRARY_OUTPUT_INTDIR@"
+config.flang_llvm_tools_dir = "@LLVM_RUNTIME_OUTPUT_INTDIR@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 
 # Support substitution of the tools_dir with user parameters. This is


### PR DESCRIPTION
Tested on OK on both out and in tree builds.
Also a small fix for end-to-end expression tests, it is still a script because it requires pgf90 so I do not want to add it default to our lit regression tests yet.